### PR TITLE
Generalise composable cow support

### DIFF
--- a/scripts/DeployMainnetSwapper.s.sol
+++ b/scripts/DeployMainnetSwapper.s.sol
@@ -18,7 +18,7 @@ library DeploymentLibrary {
     address initialPriceChecker,
     address initialLimitOrderPriceChecker,
     address initialComposableCow,
-    address initialHandler,
+    address initialTwapHandler,
     address initialRelayer
   ) internal {
     Create2Utils.create2Deploy(
@@ -32,7 +32,7 @@ library DeploymentLibrary {
         initialPriceChecker,
         initialLimitOrderPriceChecker,
         initialComposableCow,
-        initialHandler,
+        initialTwapHandler,
         initialRelayer
       )
     );

--- a/src/finance/MainnetSwapSteward.sol
+++ b/src/finance/MainnetSwapSteward.sol
@@ -89,7 +89,7 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
   mapping(address token => uint256 budget) public tokenBudget;
 
   /// @inheritdoc IMainnetSwapSteward
-  mapping(address handler => bool isAllowed) public allowedHandlers;
+  mapping(IOrderHandler handler => bool isAllowed) public allowedHandlers;
 
   constructor(
     address initialOwner,
@@ -113,9 +113,6 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
 
     COLLECTOR = collector;
     twapHandler = initialTwapHandler;
-
-    // Set the TWAP handler as allowed by default
-    allowedHandlers[initialTwapHandler] = true;
   }
 
   /// @inheritdoc IMainnetSwapSteward
@@ -184,7 +181,7 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
     onlyOwnerOrGuardian
   {
     // Validate that the handler is allowed
-    if (!allowedHandlers[address(_orderHandler)]) revert HandlerNotAllowed();
+    if (!allowedHandlers[_orderHandler]) revert HandlerNotAllowed();
 
     IOrderHandler orderHandler = IOrderHandler(address(_orderHandler));
 
@@ -345,12 +342,12 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
   }
 
   /// @inheritdoc IMainnetSwapSteward
-  function setAllowedHandler(address handler, bool allowed) external onlyOwner {
-    if (handler == address(0)) revert InvalidZeroAddress();
+  function setAllowedHandler(IOrderHandler handler, bool allowed) external onlyOwner {
+    if (address(handler) == address(0)) revert InvalidZeroAddress();
 
     allowedHandlers[handler] = allowed;
 
-    emit SetAllowedHandler(handler, allowed);
+    emit SetAllowedHandler(address(handler), allowed);
   }
 
   /// @inheritdoc IMainnetSwapSteward

--- a/src/finance/MainnetSwapSteward.sol
+++ b/src/finance/MainnetSwapSteward.sol
@@ -15,6 +15,7 @@ import {IConditionalOrder} from "src/finance/interfaces/IConditionalOrder.sol";
 import {IMilkman} from "src/finance/interfaces/IMilkman.sol";
 import {IPriceChecker} from "src/finance/interfaces/IPriceChecker.sol";
 import {IMainnetSwapSteward} from "src/finance/interfaces/IMainnetSwapSteward.sol";
+import {IOrderHandler} from "src/finance/interfaces/IOrderHandler.sol";
 
 /**
  * @title MainnetSwapSteward
@@ -64,7 +65,7 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
   address public immutable COLLECTOR;
 
   /// @inheritdoc IMainnetSwapSteward
-  address public immutable HANDLER;
+  address public immutable twapHandler;
 
   /// @inheritdoc IMainnetSwapSteward
   address public relayer;
@@ -87,6 +88,9 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
   /// @inheritdoc IMainnetSwapSteward
   mapping(address token => uint256 budget) public tokenBudget;
 
+  /// @inheritdoc IMainnetSwapSteward
+  mapping(address handler => bool isAllowed) public allowedHandlers;
+
   constructor(
     address initialOwner,
     address initialGuardian,
@@ -95,11 +99,11 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
     address initialPriceChecker,
     address initialLimitOrderPriceChecker,
     address initialComposableCow,
-    address initialHandler,
+    address initialTwapHandler,
     address initialRelayer
   ) OwnableWithGuardian(initialOwner, initialGuardian) ERC1271Forwarder(initialComposableCow) {
     if (collector == address(0)) revert InvalidZeroAddress();
-    if (initialHandler == address(0)) revert InvalidZeroAddress();
+    if (initialTwapHandler == address(0)) revert InvalidZeroAddress();
     if (initialComposableCow == address(0)) revert InvalidZeroAddress();
 
     _setMilkman(initialMilkman);
@@ -108,7 +112,10 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
     _setRelayer(initialRelayer);
 
     COLLECTOR = collector;
-    HANDLER = initialHandler;
+    twapHandler = initialTwapHandler;
+
+    // Set the TWAP handler as allowed by default
+    allowedHandlers[initialTwapHandler] = true;
   }
 
   /// @inheritdoc IMainnetSwapSteward
@@ -151,13 +158,6 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
   ) external onlyOwnerOrGuardian {
     uint256 amount = partSellAmount * numParts;
 
-    _validateCommon(fromToken, toToken, amount);
-    _transferTokensIn(fromToken, amount);
-
-    if (msg.sender != owner()) {
-      _decreaseBudget(fromToken, amount);
-    }
-
     IMainnetSwapSteward.TWAPData memory twapData = TWAPData({
       sellToken: IERC20(fromToken),
       buyToken: IERC20(toToken),
@@ -168,22 +168,71 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
       n: numParts,
       t: partDuration,
       span: span,
-      appData: bytes32(0)
+      appData: bytes32(0) // TODO: Why not allow passing the appData? Not doing it to avoid breaking changes
     });
 
     IConditionalOrder.ConditionalOrderParams memory params = IConditionalOrder.ConditionalOrderParams(
-      IConditionalOrder(HANDLER), "AaveSwapper-TWAP-Swap", abi.encode(twapData)
+      IConditionalOrder(twapHandler), "AaveSwapper-TWAP-Swap", abi.encode(twapData)
     );
 
-    bool orderExists = COMPOSABLE_COW.singleOrders(address(this), keccak256(abi.encode(params)));
+    _createComposableCowOrder(fromToken, toToken, amount, params);
+  }
 
+  /// @inheritdoc IMainnetSwapSteward
+  function createComposableCowOrder(IOrderHandler _orderHandler, bytes32 salt, bytes calldata staticInput)
+    external
+    onlyOwnerOrGuardian
+  {
+    // Validate that the handler is allowed
+    if (!allowedHandlers[address(_orderHandler)]) revert HandlerNotAllowed();
+
+    IOrderHandler orderHandler = IOrderHandler(address(_orderHandler));
+
+    // Extract order information from the staticInput
+    (address fromToken, address toToken, uint256 amount) = orderHandler.extractOrderInfo(staticInput);
+
+    IConditionalOrder.ConditionalOrderParams memory params = IConditionalOrder.ConditionalOrderParams({
+      handler: orderHandler.composableCowHandler(),
+      salt: salt,
+      staticInput: staticInput
+    });
+
+    _createComposableCowOrder(fromToken, toToken, amount, params);
+  }
+
+  /// @dev Internal function to create a composable cow order
+  /// @param fromToken The token that is being swapped from
+  /// @param toToken The token that is being swapped to
+  /// @param amount The amount of fromToken to swap
+  /// @param params The conditional order parameters
+  /// @dev The handler in params must be previously approved via allowedHandlers
+  function _createComposableCowOrder(
+    address fromToken,
+    address toToken,
+    uint256 amount,
+    IConditionalOrder.ConditionalOrderParams memory params
+  ) internal {
+    // Validate common swap parameters
+    _validateCommon(fromToken, toToken, amount);
+
+    // Transfer tokens in and decrease budget if needed
+    _transferTokensIn(fromToken, amount);
+
+    if (msg.sender != owner()) {
+      _decreaseBudget(fromToken, amount);
+    }
+
+    // Check if order already exists
+    bool orderExists = COMPOSABLE_COW.singleOrders(address(this), keccak256(abi.encode(params)));
     if (orderExists) revert OrderExists();
 
+    // Create the conditional order
     COMPOSABLE_COW.create(params, true);
 
+    // Increase allowance for the relayer
     IERC20(fromToken).safeIncreaseAllowance(relayer, amount);
 
-    emit TWAPSwapRequested(fromToken, toToken, amount);
+    emit ComposableCowOrderCreated(fromToken, toToken, amount, address(params.handler));
   }
 
   /// @inheritdoc IMainnetSwapSteward
@@ -204,6 +253,7 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
     _cancelSwap(tradeMilkman, limitOrderPriceChecker, fromToken, toToken, amount, abi.encode(amountOut));
   }
 
+  // TODO: Refactor and provide a way to cancel any composable cow order
   /// @inheritdoc IMainnetSwapSteward
   function cancelTwapSwap(
     address fromToken,
@@ -237,7 +287,7 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
         keccak256(
           abi.encode(
             IConditionalOrder.ConditionalOrderParams(
-              IConditionalOrder(HANDLER), "AaveSwapper-TWAP-Swap", abi.encode(twapData)
+              IConditionalOrder(twapHandler), "AaveSwapper-TWAP-Swap", abi.encode(twapData)
             )
           )
         )
@@ -248,7 +298,7 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
       keccak256(
         abi.encode(
           IConditionalOrder.ConditionalOrderParams(
-            IConditionalOrder(HANDLER), "AaveSwapper-TWAP-Swap", abi.encode(twapData)
+            IConditionalOrder(twapHandler), "AaveSwapper-TWAP-Swap", abi.encode(twapData)
           )
         )
       )
@@ -292,6 +342,15 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
     swapApprovedToken[fromToken][toToken] = allowed;
 
     emit SetSwappablePair(fromToken, toToken, allowed);
+  }
+
+  /// @inheritdoc IMainnetSwapSteward
+  function setAllowedHandler(address handler, bool allowed) external onlyOwner {
+    if (handler == address(0)) revert InvalidZeroAddress();
+
+    allowedHandlers[handler] = allowed;
+
+    emit SetAllowedHandler(handler, allowed);
   }
 
   /// @inheritdoc IMainnetSwapSteward

--- a/src/finance/interfaces/IMainnetSwapSteward.sol
+++ b/src/finance/interfaces/IMainnetSwapSteward.sol
@@ -155,7 +155,7 @@ interface IMainnetSwapSteward {
 
   /// @notice Returns whether a handler is allowed for conditional orders
   /// @param handler The address of the handler to check
-  function allowedHandlers(address handler) external view returns (bool);
+  function allowedHandlers(IOrderHandler handler) external view returns (bool);
 
   /// @notice Returns the address of the Milkman contract
   function milkman() external view returns (address);
@@ -303,7 +303,7 @@ interface IMainnetSwapSteward {
   /// @notice Sets a handler as allowed for conditional orders
   /// @param handler The address of the handler
   /// @param allowed Whether the handler is allowed or disallowed
-  function setAllowedHandler(address handler, bool allowed) external;
+  function setAllowedHandler(IOrderHandler handler, bool allowed) external;
 
   /// @notice Increases a token's budget (the maximum that can be swapped from)
   /// @param token The address of the token to increase the budget for

--- a/src/finance/interfaces/IMainnetSwapSteward.sol
+++ b/src/finance/interfaces/IMainnetSwapSteward.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.0;
 
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IConditionalOrder} from "./IConditionalOrder.sol";
+import {IOrderHandler} from "./IOrderHandler.sol";
 
 interface IMainnetSwapSteward {
   /// @dev Struct representing a TWAP Swap order on COW Swap
@@ -48,11 +50,19 @@ interface IMainnetSwapSteward {
   /// @dev Token pair has not been set for swapping
   error UnrecognizedTokenSwap();
 
+  /// @dev Handler is not allowed
+  error HandlerNotAllowed();
+
   /// @notice Emitted when a token is approved for swapping with its corresponding USD oracle
   /// @param fromToken The address of the token approved for swapping from
   /// @param toToken The address of the token approved to swap to
   /// @param allowed Whether token pair is allowed or disallowed
   event SetSwappablePair(address indexed fromToken, address indexed toToken, bool allowed);
+
+  /// @notice Emitted when a handler is approved for conditional orders
+  /// @param handler The address of the handler
+  /// @param allowed Whether the handler is allowed or disallowed
+  event SetAllowedHandler(address indexed handler, bool allowed);
 
   /// @notice Emitted when the Milkman contract address is updated
   /// @param oldAddress The old Milkman instance address
@@ -112,13 +122,22 @@ interface IMainnetSwapSteward {
   /// @param fromToken The token that was being swapped from
   /// @param toToken The token that was being swapped for
   /// @param totalAmount The total amount of fromToken that was going to be swapped
-  event TWAPSwapCanceled(address indexed fromToken, address indexed toToken, uint256 totalAmount);
+  event TWAPSwapCanceled(address indexed fromToken, address indexed toToken, uint256 totalAmount); // TODO: Remove, use one more generic for all composable cow orders
 
   /// @notice Emitted when a TWAP Swap order is created
   /// @param fromToken The token that is being swapped from
   /// @param toToken The token that is being swapped for
   /// @param totalAmount The total amount of fromToken that is going to be swapped
-  event TWAPSwapRequested(address indexed fromToken, address indexed toToken, uint256 totalAmount);
+  event TWAPSwapRequested(address indexed fromToken, address indexed toToken, uint256 totalAmount); // TODO: Remove, use ComposableCowOrderCreated instead
+
+  /// @notice Emitted when a ComposableCoW conditional order is created
+  /// @param fromToken The token that is being swapped from
+  /// @param toToken The token that is being swapped for
+  /// @param amount The total amount of fromToken that is going to be swapped
+  /// @param handler The handler address for the conditional order
+  event ComposableCowOrderCreated(
+    address indexed fromToken, address indexed toToken, uint256 amount, address indexed handler
+  );
 
   /// @notice Emitted when a token's budget is updated
   /// @param token The address of the token
@@ -131,8 +150,12 @@ interface IMainnetSwapSteward {
   /// @notice Returns the maximum allowed slippage for swaps (in BPS)
   function MAX_SLIPPAGE() external view returns (uint256);
 
-  /// @notice Returns address of handler of conditional orders
-  function HANDLER() external view returns (address);
+  /// @notice Returns the address of the TWAP handler
+  function twapHandler() external view returns (address);
+
+  /// @notice Returns whether a handler is allowed for conditional orders
+  /// @param handler The address of the handler to check
+  function allowedHandlers(address handler) external view returns (bool);
 
   /// @notice Returns the address of the Milkman contract
   function milkman() external view returns (address);
@@ -193,6 +216,13 @@ interface IMainnetSwapSteward {
     uint256 partDuration,
     uint256 span
   ) external;
+
+  /// @notice Creates a generic ComposableCoW conditional
+  /// @param _orderHandler The address of the order handler contract
+  /// @param salt The salt for the conditional order
+  /// @param staticInput The static input of the composable cow order
+  /// @dev The handler in params must be previously approved via allowedHandlers
+  function createComposableCowOrder(IOrderHandler _orderHandler, bytes32 salt, bytes calldata staticInput) external;
 
   /// @notice Function to cancel an existing swap
   /// @param tradeMilkman Address of the Milkman contract created upon order submission
@@ -269,6 +299,11 @@ interface IMainnetSwapSteward {
   /// @param toToken The address of the token to swap to
   /// @param allowed Sets swappable pair to allowed/disallowed
   function setSwappablePair(address fromToken, address toToken, bool allowed) external;
+
+  /// @notice Sets a handler as allowed for conditional orders
+  /// @param handler The address of the handler
+  /// @param allowed Whether the handler is allowed or disallowed
+  function setAllowedHandler(address handler, bool allowed) external;
 
   /// @notice Increases a token's budget (the maximum that can be swapped from)
   /// @param token The address of the token to increase the budget for

--- a/src/finance/interfaces/IOrderHandler.sol
+++ b/src/finance/interfaces/IOrderHandler.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IConditionalOrder} from "./IConditionalOrder.sol";
+
+/// @title IOrderHandler
+/// @notice Interface for order handlers. Order handlers extract the basic order information from the static input
+///         and return the composable cow handler address that handles the order.
+interface IOrderHandler {
+  /// @notice Extracts token information from the static input
+  /// @param staticInput The static input of the composable cow order
+  /// @return fromToken The token to swap from
+  /// @return toToken The token to swap to
+  /// @return amount The total amount to swap
+  function extractOrderInfo(bytes calldata staticInput)
+    external
+    view
+    returns (address fromToken, address toToken, uint256 amount);
+
+  /// @notice Returns the address of the composable cow handler
+  function composableCowHandler() external view returns (IConditionalOrder);
+}

--- a/tests/finance/MainnetSwapSteward.t.sol
+++ b/tests/finance/MainnetSwapSteward.t.sol
@@ -240,7 +240,7 @@ contract ConstructorTest is Test {
     assertEq(steward.milkman(), MILKMAN);
     assertEq(steward.priceChecker(), PRICE_CHECKER);
     assertEq(steward.limitOrderPriceChecker(), LIMIT_ORDER_PRICE_CHECKER);
-    assertEq(steward.HANDLER(), TWAP_HANDLER);
+    assertEq(steward.twapHandler(), TWAP_HANDLER);
     assertEq(steward.relayer(), COW_RELAYER);
   }
 }


### PR DESCRIPTION
This PR is just some experimentations to see the changes needed to allow the `MainnetSwapSteward` contract to be able to swap any arbitrary composable CoW Order.

# Motivation
This contract uses Composable CoW to create TWAPs, but doesn't allow other programmatic orders.

It also has support for Milkman, which is great, but is not activelly being mantained and requires to run some watch-tower on each network. Only mainnet has the service running. Also, milkman is less flexible than Composable CoW, which would allow to fully automate the trading strategies.

# Changes

## Registry of authorised order handlers
Order handlers are contracts that allow to extract the relevant order fields that this contract validates (`fromToken`, `toToken` and `amount`) using the specific `staticInput` from a composable cow order.

This contract also tells us the composable cow handler that should be used. 

```
interface IOrderHandler {

  function extractOrderInfo(bytes calldata staticInput)
    external
    view
    returns (address fromToken, address toToken, uint256 amount);


  function composableCowHandler() external view returns (IConditionalOrder);
}
```


This way, when this contract wants to enable a new composable cow order, it needs to:
1.  Use an existing [composable cow](https://github.com/cowprotocol/composable-cow) order or build a new one to suit your needs
2. Implement a IOrderHandler contract that points to this handler, and extracts the basic data. The method could make some additional validations on the `staticInput` making sure is safe
3. Enable the IOrderHandler using the method `setAllowedHandler(IOrderHandler handler, bool allowed)` 


## Posting a composable cow order
You can now place arbitrary orders for pre-approved order handlers:

`createComposableCowOrder(IOrderHandler _orderHandler, bytes32 salt, bytes calldata staticInput)`

this method, follows the same logic as the other trading methods. More concretely these 3 things:

```
    _validateCommon(fromToken, toToken, amount);
    
    _transferTokensIn(fromToken, amount);

    if (msg.sender != owner()) {
      _decreaseBudget(fromToken, amount);
    }
```

## TWAPs
The TWAPs work as before, technically the method that creates twaps doesn't need to be used any more because you can use `createComposableCowOrder`. It was just left for backward compatibility, and for convenience. However, the implementation has been refactored.



# Out of  scope
This is an experiment just to give some ideas on how to generalize this contract more, its not meant to be complete. For example, I didn't add the cancelation of orders, but this part can be easily implemented.

The code compiles, but I didn't add tests. I don't expect it to be merged. Its meant to be left as a draft.