### PR TITLE
CCTP Bridge Steward

### DIFF
--- a/scripts/DeployCctpBridgeSteward.s.sol
+++ b/scripts/DeployCctpBridgeSteward.s.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum} from "aave-address-book/AaveV3Ethereum.sol";
+import {AaveV3Arbitrum} from "aave-address-book/AaveV3Arbitrum.sol";
+import {AaveV3Optimism} from "aave-address-book/AaveV3Optimism.sol";
+import {AaveV3Polygon} from "aave-address-book/AaveV3Polygon.sol";
+import {AaveV3Base} from "aave-address-book/AaveV3Base.sol";
+import {
+  ArbitrumScript,
+  BaseScript,
+  EthereumScript,
+  OptimismScript,
+  PolygonScript
+} from "solidity-utils/contracts/utils/ScriptUtils.sol";
+import {CctpBridgeSteward} from "src/bridges/cctp/CctpBridgeSteward.sol";
+import {CctpConstants} from "src/bridges/cctp/CctpConstants.sol";
+
+address constant TOKEN_LOGIC = 0x3765A685a401622C060E5D700D9ad89413363a91;
+address constant GUARDIAN = 0x3765A685a401622C060E5D700D9ad89413363a91;
+bytes32 constant SALT = "Aave CCTP Bridge";
+
+contract DeployCctpBridgeArbitrum is ArbitrumScript {
+  function run() external broadcast {
+    new CctpBridgeSteward{salt: SALT}(
+      CctpConstants.ARBITRUM_TOKEN_MESSENGER,
+      CctpConstants.ARBITRUM_USDC,
+      TOKEN_LOGIC,
+      GUARDIAN,
+      address(AaveV3Arbitrum.COLLECTOR)
+    );
+  }
+}
+
+contract DeployCctpBridgeOptimism is OptimismScript {
+  function run() external broadcast {
+    new CctpBridgeSteward{salt: SALT}(
+      CctpConstants.OPTIMISM_TOKEN_MESSENGER,
+      CctpConstants.OPTIMISM_USDC,
+      TOKEN_LOGIC,
+      GUARDIAN,
+      address(AaveV3Optimism.COLLECTOR)
+    );
+  }
+}
+
+contract DeployCctpBridgePolygon is PolygonScript {
+  function run() external broadcast {
+    new CctpBridgeSteward{salt: SALT}(
+      CctpConstants.POLYGON_TOKEN_MESSENGER,
+      CctpConstants.POLYGON_USDC,
+      TOKEN_LOGIC,
+      GUARDIAN,
+      address(AaveV3Polygon.COLLECTOR)
+    );
+  }
+}
+
+contract DeployCctpBridgeBase is BaseScript {
+  function run() external broadcast {
+    new CctpBridgeSteward{salt: SALT}(
+      CctpConstants.BASE_TOKEN_MESSENGER, CctpConstants.BASE_USDC, TOKEN_LOGIC, GUARDIAN, address(AaveV3Base.COLLECTOR)
+    );
+  }
+}

--- a/src/bridges/cctp/CctpBridgeSteward.sol
+++ b/src/bridges/cctp/CctpBridgeSteward.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum} from "aave-address-book/AaveV3Ethereum.sol";
+import {ICollector} from "aave-address-book/AaveV3.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {OwnableWithGuardian} from "solidity-utils/contracts/access-control/OwnableWithGuardian.sol";
+import {RescuableBase} from "solidity-utils/contracts/utils/RescuableBase.sol";
+
+import {ICctpBridgeSteward} from "./interfaces/ICctpBridgeSteward.sol";
+import {IMessageTransmitterV2} from "./interfaces/IMessageTransmitterV2.sol";
+import {ITokenMessengerV2} from "./interfaces/ITokenMessengerV2.sol";
+import {CctpConstants} from "./CctpConstants.sol";
+
+/// @title CctpBridgeSteward
+/// @author stevyhacker, jubeira (TokenLogic)
+/// @notice Helper contract to bridge USDC using Circle's CCTP V2
+contract CctpBridgeSteward is OwnableWithGuardian, RescuableBase, ICctpBridgeSteward {
+  using SafeERC20 for IERC20;
+
+  /// @inheritdoc ICctpBridgeSteward
+  uint32 public constant DESTINATION_DOMAIN = CctpConstants.ETHEREUM_DOMAIN;
+
+  /// @inheritdoc ICctpBridgeSteward
+  address public constant MAINNET_COLLECTOR = address(AaveV3Ethereum.COLLECTOR);
+
+  /// @inheritdoc ICctpBridgeSteward
+  address public immutable TOKEN_MESSENGER;
+
+  /// @inheritdoc ICctpBridgeSteward
+  address public immutable USDC;
+
+  /// @inheritdoc ICctpBridgeSteward
+  address public immutable COLLECTOR;
+
+  /// @inheritdoc ICctpBridgeSteward
+  /// @dev Captured at deploy time from the (upgradeable) TokenMessengerV2 / MessageTransmitterV2.
+  ///      A redeploy is required if Circle migrates these contracts and the local domain changes.
+  uint32 public immutable LOCAL_DOMAIN;
+
+  /// @param tokenMessenger The TokenMessengerV2 address on this chain
+  /// @param usdc The USDC token address on this chain
+  /// @param owner The owner of the contract upon deployment
+  /// @param guardian The initial guardian of the contract upon deployment
+  /// @param collector The address of the source collector on this chain
+  constructor(address tokenMessenger, address usdc, address owner, address guardian, address collector)
+    OwnableWithGuardian(owner, guardian)
+  {
+    if (tokenMessenger == address(0)) revert InvalidZeroAddress();
+    if (usdc == address(0)) revert InvalidZeroAddress();
+    if (guardian == address(0)) revert InvalidZeroAddress();
+    if (collector == address(0)) revert InvalidZeroAddress();
+
+    TOKEN_MESSENGER = tokenMessenger;
+    USDC = usdc;
+    COLLECTOR = collector;
+
+    address localMessageTransmitter = ITokenMessengerV2(tokenMessenger).localMessageTransmitter();
+    LOCAL_DOMAIN = IMessageTransmitterV2(localMessageTransmitter).localDomain();
+    if (LOCAL_DOMAIN == DESTINATION_DOMAIN) revert InvalidLocalDomain();
+  }
+
+  /// @inheritdoc ICctpBridgeSteward
+  function bridge(uint256 amount, uint256 maxFee, TransferSpeed speed) external onlyOwnerOrGuardian {
+    if (amount == 0) revert InvalidZeroAmount();
+    if (maxFee >= amount) revert InvalidMaxFee(maxFee, amount);
+
+    uint32 finalityThreshold;
+    if (speed == TransferSpeed.Fast) {
+      finalityThreshold = CctpConstants.FAST_FINALITY_THRESHOLD;
+    } else if (speed == TransferSpeed.Standard) {
+      finalityThreshold = CctpConstants.STANDARD_FINALITY_THRESHOLD;
+    } else {
+      revert InvalidTransferSpeed();
+    }
+
+    ICollector(COLLECTOR).transfer(IERC20(USDC), address(this), amount);
+    IERC20(USDC).forceApprove(TOKEN_MESSENGER, amount);
+
+    ITokenMessengerV2(TOKEN_MESSENGER)
+      .depositForBurn(
+        amount,
+        DESTINATION_DOMAIN,
+        bytes32(uint256(uint160(MAINNET_COLLECTOR))),
+        USDC,
+        bytes32(0),
+        maxFee,
+        finalityThreshold
+      );
+
+    // Clear the allowance to prevent any potential issues down the line.
+    IERC20(USDC).forceApprove(TOKEN_MESSENGER, 0);
+
+    emit Bridge(USDC, DESTINATION_DOMAIN, MAINNET_COLLECTOR, amount, speed);
+  }
+
+  /// @inheritdoc ICctpBridgeSteward
+  function rescueToken(address token) external onlyOwnerOrGuardian {
+    _emergencyTokenTransfer(token, COLLECTOR, type(uint256).max);
+  }
+
+  /// @inheritdoc ICctpBridgeSteward
+  function rescueEth() external onlyOwnerOrGuardian {
+    _emergencyEtherTransfer(COLLECTOR, address(this).balance);
+  }
+
+  /// @inheritdoc RescuableBase
+  function maxRescue(address token) public view override(RescuableBase) returns (uint256) {
+    return IERC20(token).balanceOf(address(this));
+  }
+}

--- a/src/bridges/cctp/CctpConstants.sol
+++ b/src/bridges/cctp/CctpConstants.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title CctpConstants
+/// @notice Constants for CCTP V2 bridge testing
+/// @dev Domain IDs from https://developers.circle.com/cctp/cctp-supported-blockchains
+library CctpConstants {
+  // CCTP Domain IDs
+  uint32 public constant ETHEREUM_DOMAIN = 0;
+  uint32 public constant AVALANCHE_DOMAIN = 1;
+  uint32 public constant OPTIMISM_DOMAIN = 2;
+  uint32 public constant ARBITRUM_DOMAIN = 3;
+  uint32 public constant SOLANA_DOMAIN = 5;
+  uint32 public constant BASE_DOMAIN = 6;
+  uint32 public constant POLYGON_DOMAIN = 7;
+  uint32 public constant UNICHAIN_DOMAIN = 10;
+  uint32 public constant LINEA_DOMAIN = 11;
+  uint32 public constant SONIC_DOMAIN = 13;
+  uint32 public constant MONAD_DOMAIN = 15;
+  uint32 public constant INK_DOMAIN = 21;
+
+  /// @notice Finality threshold constant for Fast Transfer is 1000 and means just tx confirmation is sufficient
+  /// @dev Required confirmations per chain https://developers.circle.com/cctp/required-block-confirmations#cctp-fast-message-attestation-times
+  uint32 public constant FAST_FINALITY_THRESHOLD = 1000;
+
+  /// @notice Finality threshold constant for Standard Transfer is 2000 and means hard finality is requested
+  /// @dev Required confirmations per chain https://developers.circle.com/cctp/required-block-confirmations#cctp-standard-message-attestation-times
+  uint32 public constant STANDARD_FINALITY_THRESHOLD = 2000;
+
+  // Mainnet TokenMessengerV2 addresses
+  // https://etherscan.io/address/0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d
+  address public constant ETHEREUM_TOKEN_MESSENGER = 0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d;
+  // https://arbiscan.io/address/0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d
+  address public constant ARBITRUM_TOKEN_MESSENGER = 0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d;
+  // https://basescan.org/address/0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d
+  address public constant BASE_TOKEN_MESSENGER = 0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d;
+  // https://optimistic.etherscan.io/address/0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d
+  address public constant OPTIMISM_TOKEN_MESSENGER = 0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d;
+  // https://polygonscan.com/address/0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d
+  address public constant POLYGON_TOKEN_MESSENGER = 0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d;
+
+  // Mainnet USDC addresses
+  // https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+  address public constant ETHEREUM_USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+  // https://arbiscan.io/address/0xaf88d065e77c8cC2239327C5EDb3A432268e5831
+  address public constant ARBITRUM_USDC = 0xaf88d065e77c8cC2239327C5EDb3A432268e5831;
+  // https://basescan.org/address/0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
+  address public constant BASE_USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+  // https://optimistic.etherscan.io/address/0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85
+  address public constant OPTIMISM_USDC = 0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85;
+  // https://polygonscan.com/address/0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359
+  address public constant POLYGON_USDC = 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359;
+}

--- a/src/bridges/cctp/README.md
+++ b/src/bridges/cctp/README.md
@@ -1,0 +1,139 @@
+# Aave CCTP Bridge
+
+The AaveCctpBridge is a contract to facilitate bridging USDC across chains using Circle's Cross-Chain Transfer Protocol (CCTP) V2. The contract provides a simplified interface for Aave DAO governance to move USDC between supported networks.
+
+## Features
+
+- Bridge USDC from a supported source chain back to the Aave Mainnet Collector via CCTP V2
+- Support for both Fast and Standard transfer speeds
+- Steward access model (`owner` + `guardian`) for operational execution
+- Bridges pull USDC from a pre-configured source `COLLECTOR` (set at deploy time)
+- Bridges always send to the Aave Mainnet Collector on the Ethereum domain — the receiver is hardcoded as the `MAINNET_COLLECTOR` constant (sourced from aave-address-book's `AaveV3Ethereum.COLLECTOR`) and cannot be changed
+
+## Transfer Speeds
+
+CCTP V2 supports two transfer speed modes:
+
+| Speed    | Finality Threshold | Description                      |
+| -------- | ------------------ | -------------------------------- |
+| Fast     | 1000               | Faster transfer, may incur a fee |
+| Standard | 2000               | Slower transfer, no fee          |
+
+Essentially, the Fast mode is just a tx confirmation is sufficient while the Standard mode requires hard finality and a large number of mined blocks.
+The exact numbers per chain can be found in the Circle documentation:
+
+- [cctp-fast-message-attestation-times](https://developers.circle.com/cctp/required-block-confirmations#cctp-fast-message-attestation-times)
+- [cctp-standard-message-attestation-times](https://developers.circle.com/cctp/required-block-confirmations#cctp-standard-message-attestation-times)
+
+The `maxFee` parameter allows specifying the maximum fee (in USDC) willing to pay for Fast transfers.
+
+- For `TransferSpeed.Fast`, `maxFee` is the maximum fee you are willing to pay (in USDC base units).
+- For `TransferSpeed.Standard`, fees are `0` (per Iris) so `maxFee` should be set to `0`.
+
+### Querying fees for Fast transfers
+
+Circle exposes the minimum fee rate for a route (in basis points) via Iris. To derive a `maxFee` for `TransferSpeed.Fast`, query:
+
+Example:
+
+```bash
+# Arbitrum (3) -> Base (6)
+curl -s "https://iris-api.circle.com/v2/burn/USDC/fees/3/6"
+```
+
+- Mainnet: `GET https://iris-api.circle.com/v2/burn/USDC/fees/{sourceDomainId}/{destDomainId}`
+- Testnet: `GET https://iris-api-sandbox.circle.com/v2/burn/USDC/fees/{sourceDomainId}/{destDomainId}`
+
+The response includes entries for `finalityThreshold` `1000` (Fast / Confirmed) and `2000` (Standard / Finalized).
+
+To derive a `maxFee` for `TransferSpeed.Fast`, use the `minimumFee` where `finalityThreshold == 1000`, then compute (rounding up):
+
+`maxFee = ceil(amount * minimumFee / 10_000)`
+
+**Denomination / decimals**
+
+- Onchain, both `amount` and `maxFee` are expected in the token’s smallest unit (for USDC: `6` decimals, i.e. `1 USDC = 1_000_000` base units).
+- The Iris API returns a fee _rate_ (`minimumFee` in bps). This value can be fractional (e.g. `1.3` bps), so do the computation off-chain using decimal math and then round up to base units.
+
+Example (1000 USDC, `minimumFee = 1.3` bps):
+
+- `amountBaseUnits = 1000 * 1_000_000 = 1_000_000_000`
+- choose `scale = 10` (one decimal place), so `minimumFeeScaled = 13`
+- `maxFeeBaseUnits = ceil(1_000_000_000 * 13 / (10_000 * 10)) = 130_000`
+- `130_000` base units = `0.13` USDC
+
+Note: the API returns a fee _rate_ (`minimumFee` in bps), not a precomputed absolute `maxFee`; you derive the absolute value from your `amount`.
+
+## Permissions
+
+The contract implements `OwnableWithGuardian` for permissioned functions.
+The owner is expected to be the respective network's Level 1 Executor (Governance), while the guardian provides an operational backup path.
+
+`bridge()` can be called by `owner` or `guardian`. The destination domain and the Mainnet Collector receiver are hardcoded constants — there are no setters.
+
+## Security Considerations
+
+The contract exposes `rescueToken()` and `rescueEth()`, callable by `owner` or `guardian`.
+Both rescue methods always transfer assets back to `COLLECTOR` (not arbitrary recipients).
+
+The contract does not expose a `receive()` fallback, so ETH cannot arrive via a plain transfer. `rescueEth()` is retained as a safety net for ETH that arrives via `selfdestruct` or pre-deploy funding.
+
+## CCTP Domain IDs
+
+Domain IDs are defined by Circle's CCTP. The complete list can be found in the [CCTP documentation](https://developers.circle.com/cctp/cctp-supported-blockchains). Only the Ethereum (destination) and source-chain domains are operationally relevant for this steward; the rest of the table below is for reference.
+
+| Network   | Domain ID |
+| --------- | --------- |
+| Ethereum  | 0         |
+| Avalanche | 1         |
+| Optimism  | 2         |
+| Arbitrum  | 3         |
+| Solana    | 5         |
+| Base      | 6         |
+| Polygon   | 7         |
+| Unichain  | 10        |
+| Linea     | 11        |
+| Sonic     | 13        |
+| Monad     | 15        |
+| Ink       | 21        |
+
+## Functions
+
+```solidity
+function bridge(
+  uint256 amount,
+  uint256 maxFee,
+  TransferSpeed speed
+) external onlyOwnerOrGuardian;
+```
+
+Bridges USDC to `MAINNET_COLLECTOR` on the Ethereum domain. The bridge contract pulls USDC from the source-chain `COLLECTOR` via `ICollector.transfer`, so the bridge must hold the Collector `FUNDS_ADMIN` role. The destination domain (`DESTINATION_DOMAIN`) and recipient (`MAINNET_COLLECTOR`) are compile-time constants — to change either, the contract source must be modified and redeployed.
+
+Parameters:
+
+- `amount`: Amount of USDC to bridge (must be > 0)
+- `maxFee`: Maximum fee in USDC for Fast transfers (must be < `amount`)
+- `speed`: `TransferSpeed.Fast` or `TransferSpeed.Standard`
+
+Note: `LOCAL_DOMAIN` is read once at deploy time from Circle's (upgradeable) `TokenMessengerV2` / `MessageTransmitterV2`. If Circle ever migrates those contracts and the local domain changes, this steward must be redeployed.
+
+## Contract Addresses
+
+### TokenMessengerV2 (CCTP V2)
+
+All networks use the same TokenMessengerV2 address: `0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d`
+
+### Native USDC Addresses
+
+| Network  | USDC Address                                 |
+| -------- | -------------------------------------------- |
+| Ethereum | `0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48` |
+| Arbitrum | `0xaf88d065e77c8cC2239327C5EDb3A432268e5831` |
+| Base     | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| Optimism | `0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85` |
+| Polygon  | `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` |
+
+## References
+
+- [CCTP V2 Documentation](https://developers.circle.com/cctp)
+- [CCTP Supported Blockchains](https://developers.circle.com/cctp/cctp-supported-blockchains)

--- a/src/bridges/cctp/interfaces/ICctpBridgeSteward.sol
+++ b/src/bridges/cctp/interfaces/ICctpBridgeSteward.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title ICctpBridgeSteward
+/// @author TokenLogic
+/// @notice Interface for the Aave CCTP V2 Bridge adapter for USDC cross-chain transfers
+interface ICctpBridgeSteward {
+  /// @notice Transfer speed options for CCTP V2
+  enum TransferSpeed {
+    Fast, // Finality threshold 1000 - faster but with fee
+    Standard // Finality threshold 2000 - slower but potentially lower/no fee
+  }
+
+  /// @notice Emitted when a bridge transfer is initiated
+  /// @param token The address of the bridged token (USDC)
+  /// @param destinationDomain The CCTP domain of the destination chain
+  /// @param receiver The recipient address on the destination chain (bytes32 to support non-EVM)
+  /// @param amount The amount of tokens bridged
+  /// @param speed The transfer speed used (Fast or Standard)
+  event Bridge(
+    address indexed token,
+    uint32 indexed destinationDomain,
+    address indexed receiver,
+    uint256 amount,
+    TransferSpeed speed
+  );
+
+  /// @dev `receive` callback was called with non-zero ETH value, which is not supported
+  error CannotReceiveEther();
+
+  /// @dev Contract was deployed to Ethereum mainnet, which does not require a bridge
+  error InvalidLocalDomain();
+
+  /// @dev maxFee is greater than or equal to the amount being bridged, which is invalid
+  error InvalidMaxFee(uint256 maxFee, uint256 amount);
+
+  /// @dev TransferSpeed value is not a recognised member of the enum
+  error InvalidTransferSpeed();
+
+  /// @dev Constructor parameter is zero address
+  error InvalidZeroAddress();
+
+  /// @dev Amount provided is zero
+  error InvalidZeroAmount();
+
+  /// @notice Bridges USDC to a destination chain using CCTP V2
+  /// @param amount The amount of USDC to bridge, denominated in USDC with 6 decimals, 1 USDC = 1_000_000
+  /// @param maxFee Maximum fee willing to pay for a Fast Transfer, denominated in USDC with 6 decimals, 1 USDC = 1_000_000
+  /// @param speed Transfer speed (Fast or Standard)
+  function bridge(uint256 amount, uint256 maxFee, TransferSpeed speed) external;
+
+  /// @notice Rescues an ERC20 token balance to the source collector
+  /// @param token The token address to rescue
+  function rescueToken(address token) external;
+
+  /// @notice Rescues native token balance to the source collector
+  function rescueEth() external;
+
+  /// @notice Returns the CCTP domain identifier for the destination chain (Ethereum Mainnet)
+  function DESTINATION_DOMAIN() external view returns (uint32);
+
+  /// @notice Returns the TokenMessengerV2 contract address
+  function TOKEN_MESSENGER() external view returns (address);
+
+  /// @notice Returns the USDC token address on this chain
+  function USDC() external view returns (address);
+
+  /// @notice Returns the source collector address on this chain
+  function COLLECTOR() external view returns (address);
+
+  /// @notice Returns the Mainnet collector address (destination receiver) for bridge transfers
+  function MAINNET_COLLECTOR() external view returns (address);
+
+  /// @notice Returns the local CCTP domain identifier
+  /// @dev Captured at deploy time from the (upgradeable) TokenMessengerV2 / MessageTransmitterV2.
+  ///      A redeploy is required if Circle migrates these contracts and the local domain changes.
+  function LOCAL_DOMAIN() external view returns (uint32);
+}

--- a/src/bridges/cctp/interfaces/IMessageTransmitterV2.sol
+++ b/src/bridges/cctp/interfaces/IMessageTransmitterV2.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title IMessageTransmitterV2
+/// @notice Minimal interface for Circle's CCTP V2 MessageTransmitter contract
+interface IMessageTransmitterV2 {
+  function localDomain() external view returns (uint32);
+}

--- a/src/bridges/cctp/interfaces/ITokenMessengerV2.sol
+++ b/src/bridges/cctp/interfaces/ITokenMessengerV2.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title ITokenMessengerV2
+/// @notice Interface for Circle's CCTP V2 TokenMessenger contract
+/// @dev https://developers.circle.com/cctp/evm-smart-contracts#tokenmessengerv2
+interface ITokenMessengerV2 {
+  /// @notice Address of the local MessageTransmitterV2 contract
+  function localMessageTransmitter() external view returns (address);
+
+  /// @notice Deposits and burns tokens from sender to be minted on destination domain
+  /// @param amount Amount of tokens to deposit and burn
+  /// @param destinationDomain Destination domain identifier
+  /// @param mintRecipient Address of mint recipient on destination domain (as bytes32)
+  /// @param burnToken Address of contract to burn deposited tokens
+  /// @param destinationCaller Address that can call receiveMessage on destination (bytes32(0) for any)
+  /// @param maxFee Maximum fee for Fast Transfer (in burn token units)
+  /// @param minFinalityThreshold Minimum finality level (1000 for Fast, 2000 for Standard)
+  function depositForBurn(
+    uint256 amount,
+    uint32 destinationDomain,
+    bytes32 mintRecipient,
+    address burnToken,
+    bytes32 destinationCaller,
+    uint256 maxFee,
+    uint32 minFinalityThreshold
+  ) external;
+}

--- a/src/finance/MainnetSwapSteward.sol
+++ b/src/finance/MainnetSwapSteward.sol
@@ -231,8 +231,7 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
       appData: bytes32(0)
     });
 
-    if (
-      !COMPOSABLE_COW.singleOrders(
+    if (!COMPOSABLE_COW.singleOrders(
         address(this),
         keccak256(
           abi.encode(
@@ -241,8 +240,7 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
             )
           )
         )
-      )
-    ) revert OrderDoesNotExist();
+      )) revert OrderDoesNotExist();
 
     COMPOSABLE_COW.remove(
       keccak256(
@@ -370,9 +368,10 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
 
     IERC20(fromToken).safeIncreaseAllowance(milkman, amount);
 
-    IMilkman(milkman).requestSwapExactTokensForTokens(
-      amount, IERC20(fromToken), IERC20(toToken), recipient, bytes32(0), _priceChecker, priceCheckerData
-    );
+    IMilkman(milkman)
+      .requestSwapExactTokensForTokens(
+        amount, IERC20(fromToken), IERC20(toToken), recipient, bytes32(0), _priceChecker, priceCheckerData
+      );
   }
 
   /// @notice Internal function that handles swap cancellations
@@ -392,9 +391,8 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
   ) internal {
     uint256 balanceBefore = IERC20(fromToken).balanceOf(address(this));
 
-    IMilkman(tradeMilkman).cancelSwap(
-      amount, IERC20(fromToken), IERC20(toToken), COLLECTOR, bytes32(0), _priceChecker, priceCheckerData
-    );
+    IMilkman(tradeMilkman)
+      .cancelSwap(amount, IERC20(fromToken), IERC20(toToken), COLLECTOR, bytes32(0), _priceChecker, priceCheckerData);
 
     uint256 balanceDiff = IERC20(fromToken).balanceOf(address(this)) - balanceBefore;
 

--- a/src/maintenance/ClinicStewardBase.sol
+++ b/src/maintenance/ClinicStewardBase.sol
@@ -152,7 +152,8 @@ abstract contract ClinicStewardBase is IClinicSteward, RescuableBase, Multicall,
         borrower: users[i],
         debtToCover: type(uint256).max,
         receiveAToken: true
-      }) {} catch {
+      }) {}
+      catch {
         maxDebtAmount -= amounts[i];
       }
     }
@@ -235,10 +236,7 @@ abstract contract ClinicStewardBase is IClinicSteward, RescuableBase, Multicall,
 
     if (dollarAmount > oldAvailableBudget) {
       revert AvailableBudgetExceeded({
-        asset: asset,
-        assetAmount: amount,
-        dollarAmount: dollarAmount,
-        availableBudget: oldAvailableBudget
+        asset: asset, assetAmount: amount, dollarAmount: dollarAmount, availableBudget: oldAvailableBudget
       });
     }
 

--- a/tests/bridges/cctp/CctpBridgeSteward.t.sol
+++ b/tests/bridges/cctp/CctpBridgeSteward.t.sol
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+
+import {AaveV3Arbitrum} from "aave-address-book/AaveV3Arbitrum.sol";
+import {AaveV3Ethereum} from "aave-address-book/AaveV3Ethereum.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
+import {ERC20Mock} from "openzeppelin-contracts/contracts/mocks/token/ERC20Mock.sol";
+import {IAccessControl} from "openzeppelin-contracts/contracts/access/IAccessControl.sol";
+import {IWithGuardian} from "solidity-utils/contracts/access-control/interfaces/IWithGuardian.sol";
+
+import {CctpBridgeSteward} from "src/bridges/cctp/CctpBridgeSteward.sol";
+import {ICctpBridgeSteward} from "src/bridges/cctp/interfaces/ICctpBridgeSteward.sol";
+import {ITokenMessengerV2} from "src/bridges/cctp/interfaces/ITokenMessengerV2.sol";
+import {IMessageTransmitterV2} from "src/bridges/cctp/interfaces/IMessageTransmitterV2.sol";
+import {CctpConstants} from "src/bridges/cctp/CctpConstants.sol";
+
+contract CctpBridgeStewardTestBase is Test {
+  CctpBridgeSteward public bridge;
+  IERC20 public usdc = IERC20(CctpConstants.ARBITRUM_USDC);
+  address public tokenMessenger = CctpConstants.ARBITRUM_TOKEN_MESSENGER;
+  address public collector = address(AaveV3Arbitrum.COLLECTOR);
+  address public receiver = address(AaveV3Ethereum.COLLECTOR);
+  address public owner = makeAddr("owner");
+  address public guardian = makeAddr("guardian");
+  address public alice = makeAddr("alice");
+
+  uint256 public constant AMOUNT = 10_000e6; // 10k USDC
+
+  function _deployBridge() internal returns (CctpBridgeSteward) {
+    return new CctpBridgeSteward(tokenMessenger, address(usdc), owner, guardian, collector);
+  }
+
+  function _addressToBytes32(address addr) internal pure returns (bytes32) {
+    return bytes32(uint256(uint160(addr)));
+  }
+
+  function _fundCollector(uint256 amount) internal {
+    deal(address(usdc), collector, amount);
+  }
+
+  function setUp() public virtual {
+    string memory rpcUrl = vm.envOr("RPC_ARBITRUM", string(""));
+    vm.createSelectFork(rpcUrl, 459740700);
+    bridge = _deployBridge();
+
+    _fundCollector(AMOUNT);
+
+    bytes32 fundsAdminRole = AaveV3Arbitrum.COLLECTOR.FUNDS_ADMIN_ROLE();
+    vm.prank(AaveV3Arbitrum.ACL_ADMIN);
+    IAccessControl(collector).grantRole(fundsAdminRole, address(bridge));
+  }
+}
+
+contract BridgeFailuresTest is CctpBridgeStewardTestBase {
+  function test_revertsIf_callerNotOwnerOrGuardian() public {
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IWithGuardian.OnlyGuardianOrOwnerInvalidCaller.selector, alice));
+    bridge.bridge(AMOUNT, 0, ICctpBridgeSteward.TransferSpeed.Fast);
+  }
+
+  function test_revertsIf_zeroAmount() public {
+    vm.prank(owner);
+    vm.expectRevert(ICctpBridgeSteward.InvalidZeroAmount.selector);
+    bridge.bridge(0, 0, ICctpBridgeSteward.TransferSpeed.Fast);
+  }
+
+  function test_revertsIf_maxFeeGteAmount() public {
+    uint256 maxFee = AMOUNT;
+    vm.prank(owner);
+    vm.expectRevert(abi.encodeWithSelector(ICctpBridgeSteward.InvalidMaxFee.selector, maxFee, AMOUNT));
+    bridge.bridge(AMOUNT, maxFee, ICctpBridgeSteward.TransferSpeed.Fast);
+  }
+}
+
+contract ConstructorTest is CctpBridgeStewardTestBase {
+  function test_immutables() public view {
+    assertEq(bridge.TOKEN_MESSENGER(), tokenMessenger, "TOKEN_MESSENGER mismatch");
+    assertEq(bridge.USDC(), address(usdc), "USDC mismatch");
+    assertEq(bridge.COLLECTOR(), collector, "COLLECTOR mismatch");
+    assertEq(bridge.MAINNET_COLLECTOR(), receiver, "MAINNET_COLLECTOR mismatch");
+    assertEq(bridge.LOCAL_DOMAIN(), CctpConstants.ARBITRUM_DOMAIN, "LOCAL_DOMAIN mismatch");
+    assertEq(bridge.DESTINATION_DOMAIN(), CctpConstants.ETHEREUM_DOMAIN, "DESTINATION_DOMAIN mismatch");
+    assertEq(bridge.owner(), owner, "owner mismatch");
+    assertEq(bridge.guardian(), guardian, "guardian mismatch");
+  }
+
+  function test_revertsIf_localDomainEqualsDestination() public {
+    address localMessageTransmitter = makeAddr("localMessageTransmitter");
+    vm.mockCall(
+      tokenMessenger, abi.encodeCall(ITokenMessengerV2.localMessageTransmitter, ()), abi.encode(localMessageTransmitter)
+    );
+    vm.mockCall(
+      localMessageTransmitter,
+      abi.encodeCall(IMessageTransmitterV2.localDomain, ()),
+      abi.encode(CctpConstants.ETHEREUM_DOMAIN)
+    );
+
+    vm.expectRevert(ICctpBridgeSteward.InvalidLocalDomain.selector);
+    new CctpBridgeSteward(tokenMessenger, address(usdc), owner, guardian, collector);
+  }
+
+  function test_revertsIf_constructorTokenMessengerZero() public {
+    vm.expectRevert(ICctpBridgeSteward.InvalidZeroAddress.selector);
+    new CctpBridgeSteward(address(0), CctpConstants.ETHEREUM_USDC, owner, guardian, collector);
+  }
+
+  function test_revertsIf_constructorUsdcZero() public {
+    vm.expectRevert(ICctpBridgeSteward.InvalidZeroAddress.selector);
+    new CctpBridgeSteward(CctpConstants.ETHEREUM_TOKEN_MESSENGER, address(0), owner, guardian, collector);
+  }
+
+  function test_revertsIf_constructorOwnerZero() public {
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableInvalidOwner.selector, address(0)));
+    new CctpBridgeSteward(
+      CctpConstants.ETHEREUM_TOKEN_MESSENGER, CctpConstants.ETHEREUM_USDC, address(0), guardian, collector
+    );
+  }
+
+  function test_revertsIf_constructorGuardianZero() public {
+    vm.expectRevert(ICctpBridgeSteward.InvalidZeroAddress.selector);
+    new CctpBridgeSteward(
+      CctpConstants.ETHEREUM_TOKEN_MESSENGER, CctpConstants.ETHEREUM_USDC, owner, address(0), collector
+    );
+  }
+
+  function test_revertsIf_constructorCollectorZero() public {
+    vm.expectRevert(ICctpBridgeSteward.InvalidZeroAddress.selector);
+    new CctpBridgeSteward(
+      CctpConstants.ETHEREUM_TOKEN_MESSENGER, CctpConstants.ETHEREUM_USDC, owner, guardian, address(0)
+    );
+  }
+}
+
+contract BridgeTest is CctpBridgeStewardTestBase {
+  function test_bridge_fast_owner() public {
+    _bridge(owner, AMOUNT / 100, ICctpBridgeSteward.TransferSpeed.Fast);
+  }
+
+  function test_bridge_fast_guardian() public {
+    _bridge(guardian, AMOUNT / 100, ICctpBridgeSteward.TransferSpeed.Fast);
+  }
+
+  function test_bridge_standard_owner() public {
+    _bridge(owner, 0, ICctpBridgeSteward.TransferSpeed.Standard);
+  }
+
+  function test_bridge_standard_guardian() public {
+    _bridge(guardian, 0, ICctpBridgeSteward.TransferSpeed.Standard);
+  }
+
+  function _bridge(address caller, uint256 maxFee, ICctpBridgeSteward.TransferSpeed speed) internal {
+    uint256 collectorBalanceBefore = usdc.balanceOf(collector);
+
+    vm.expectEmit();
+    emit ICctpBridgeSteward.Bridge(address(usdc), CctpConstants.ETHEREUM_DOMAIN, receiver, AMOUNT, speed);
+
+    vm.prank(caller);
+    bridge.bridge(AMOUNT, maxFee, speed);
+
+    assertEq(usdc.balanceOf(address(bridge)), 0, "Bridge should have no USDC left");
+    assertEq(usdc.balanceOf(collector), collectorBalanceBefore - AMOUNT, "Collector should transfer USDC");
+    assertEq(
+      usdc.allowance(address(bridge), tokenMessenger), 0, "Bridge should have no USDC allowance for TokenMessenger"
+    );
+  }
+}
+
+contract RescuableTest is CctpBridgeStewardTestBase {
+  function test_rescueToken_guardian() public {
+    deal(address(usdc), address(bridge), AMOUNT);
+
+    uint256 collectorBalanceBefore = usdc.balanceOf(collector);
+
+    vm.prank(guardian);
+    bridge.rescueToken(address(usdc));
+
+    assertEq(usdc.balanceOf(address(bridge)), 0, "Rescue bridge should have no USDC left");
+    assertEq(usdc.balanceOf(collector), collectorBalanceBefore + AMOUNT, "Collector should receive rescued USDC");
+  }
+
+  function test_rescueToken_owner() public {
+    deal(address(usdc), address(bridge), AMOUNT);
+
+    uint256 collectorBalanceBefore = usdc.balanceOf(collector);
+
+    vm.prank(owner);
+    bridge.rescueToken(address(usdc));
+
+    assertEq(usdc.balanceOf(address(bridge)), 0, "Rescue bridge should have no USDC left");
+    assertEq(usdc.balanceOf(collector), collectorBalanceBefore + AMOUNT, "Collector should receive rescued USDC");
+  }
+
+  function test_rescueToken_nonUsdc() public {
+    IERC20 other = new ERC20Mock();
+    deal(address(other), address(bridge), AMOUNT);
+
+    vm.prank(owner);
+    bridge.rescueToken(address(other));
+
+    assertEq(other.balanceOf(address(bridge)), 0, "Bridge should have no token left");
+    assertEq(other.balanceOf(collector), AMOUNT, "Collector should receive rescued token");
+  }
+
+  function test_rescueToken_revertsIf_notOwnerOrGuardian() public {
+    deal(address(usdc), address(bridge), AMOUNT);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IWithGuardian.OnlyGuardianOrOwnerInvalidCaller.selector, alice));
+    bridge.rescueToken(address(usdc));
+  }
+
+  function test_rescueEth_owner() public {
+    uint256 rescueAmount = 1 ether;
+    vm.deal(address(bridge), rescueAmount);
+    assertEq(address(bridge).balance, rescueAmount, "Bridge should have ETH to rescue");
+
+    uint256 collectorBalanceBefore = collector.balance;
+
+    vm.prank(owner);
+    bridge.rescueEth();
+
+    assertEq(address(bridge).balance, 0, "Bridge should have no ETH left");
+    assertEq(collector.balance, collectorBalanceBefore + rescueAmount, "Collector should receive rescued ETH");
+  }
+
+  function test_rescueEth_guardian() public {
+    uint256 rescueAmount = 1 ether;
+    vm.deal(address(bridge), rescueAmount);
+
+    uint256 collectorBalanceBefore = collector.balance;
+
+    vm.prank(guardian);
+    bridge.rescueEth();
+
+    assertEq(address(bridge).balance, 0, "Bridge should have no ETH left");
+    assertEq(collector.balance, collectorBalanceBefore + rescueAmount, "Collector should receive rescued ETH");
+  }
+
+  function test_rescueEth_revertsIf_notOwnerOrGuardian() public {
+    // Bridge cannot receive ether through regular transfers, so we use vm.deal directly.
+    vm.deal(address(bridge), 1 ether);
+
+    vm.prank(alice);
+    vm.expectRevert(abi.encodeWithSelector(IWithGuardian.OnlyGuardianOrOwnerInvalidCaller.selector, alice));
+    bridge.rescueEth();
+  }
+
+  function test_maxRescue_returnsFullBalance() public {
+    deal(address(usdc), address(bridge), AMOUNT);
+
+    assertEq(bridge.maxRescue(address(usdc)), AMOUNT);
+  }
+}

--- a/tests/finance/MainnetSwapSteward.t.sol
+++ b/tests/finance/MainnetSwapSteward.t.sol
@@ -792,9 +792,8 @@ contract CancelTWAPSwapTest is MainnetSwapStewardTest {
 
     // Creating this order yields the following order hash:
     // 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    bool orderExists = IComposableCow(COMPOSABLE_COW).singleOrders(
-      address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    );
+    bool orderExists = IComposableCow(COMPOSABLE_COW)
+      .singleOrders(address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28);
 
     assertEq(steward.tokenBudget(AaveV3EthereumAssets.USDC_UNDERLYING), budgetBefore - (amount * numParts));
     assertTrue(orderExists, "Order does not exist");
@@ -812,9 +811,8 @@ contract CancelTWAPSwapTest is MainnetSwapStewardTest {
       0
     );
 
-    orderExists = IComposableCow(COMPOSABLE_COW).singleOrders(
-      address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    );
+    orderExists = IComposableCow(COMPOSABLE_COW)
+      .singleOrders(address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28);
     assertTrue(orderExists, "Order incorrectly removed");
     vm.stopPrank();
   }
@@ -846,9 +844,8 @@ contract CancelTWAPSwapTest is MainnetSwapStewardTest {
 
     // Creating this order yields the following order hash:
     // 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    bool orderExists = IComposableCow(COMPOSABLE_COW).singleOrders(
-      address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    );
+    bool orderExists = IComposableCow(COMPOSABLE_COW)
+      .singleOrders(address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28);
 
     assertEq(steward.tokenBudget(AaveV3EthereumAssets.USDC_UNDERLYING), budgetBefore - (amount * numParts));
     assertTrue(orderExists, "Order does not exist");
@@ -868,9 +865,8 @@ contract CancelTWAPSwapTest is MainnetSwapStewardTest {
       0
     );
 
-    orderExists = IComposableCow(COMPOSABLE_COW).singleOrders(
-      address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    );
+    orderExists = IComposableCow(COMPOSABLE_COW)
+      .singleOrders(address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28);
 
     // Budget does not increase
     assertEq(steward.tokenBudget(AaveV3EthereumAssets.USDC_UNDERLYING), budgetBefore - (amount * numParts));
@@ -905,9 +901,8 @@ contract CancelTWAPSwapTest is MainnetSwapStewardTest {
 
     // Creating this order yields the following order hash:
     // 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    bool orderExists = IComposableCow(COMPOSABLE_COW).singleOrders(
-      address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    );
+    bool orderExists = IComposableCow(COMPOSABLE_COW)
+      .singleOrders(address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28);
 
     assertEq(steward.tokenBudget(AaveV3EthereumAssets.USDC_UNDERLYING), budgetBefore - (amount * numParts));
     assertTrue(orderExists, "Order does not exist");
@@ -934,9 +929,8 @@ contract CancelTWAPSwapTest is MainnetSwapStewardTest {
       1
     );
 
-    orderExists = IComposableCow(COMPOSABLE_COW).singleOrders(
-      address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    );
+    orderExists = IComposableCow(COMPOSABLE_COW)
+      .singleOrders(address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28);
 
     // Budget does not increase
     assertEq(steward.tokenBudget(AaveV3EthereumAssets.USDC_UNDERLYING), budgetBefore - (amount * numParts));

--- a/tests/finance/RewardsSteward.t.sol
+++ b/tests/finance/RewardsSteward.t.sol
@@ -30,9 +30,8 @@ contract RewardsStewardTest is Test {
     steward = new RewardsSteward(address(AaveV3Ethereum.COLLECTOR), AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER);
 
     vm.prank(AaveV3Ethereum.EMISSION_MANAGER);
-    IRewardsController(AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER).setClaimer(
-      address(AaveV3Ethereum.COLLECTOR), address(steward)
-    );
+    IRewardsController(AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER)
+      .setClaimer(address(AaveV3Ethereum.COLLECTOR), address(steward));
   }
 }
 

--- a/tests/maintenance/ClinicStewardV2.t.sol
+++ b/tests/maintenance/ClinicStewardV2.t.sol
@@ -168,8 +168,8 @@ contract ClinicStewardV2Test is ClinicStewardV2BaseTest {
 
     assertEq(collectorBalanceBefore - collectorBalanceAfter, totalBadDebt);
 
-    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertApproxEqRel(steward.availableBudget(), availableBudget - debtDollarAmount, 0.0001e18);
 
     for (uint256 i = 0; i < usersWithBadDebt.length; i++) {
@@ -195,8 +195,8 @@ contract ClinicStewardV2Test is ClinicStewardV2BaseTest {
       100
     );
 
-    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertApproxEqRel(steward.availableBudget(), availableBudget - debtDollarAmount, 0.0001e18);
 
     for (uint256 i = 0; i < usersWithBadDebt.length; i++) {
@@ -218,8 +218,8 @@ contract ClinicStewardV2Test is ClinicStewardV2BaseTest {
   }
 
   function test_reverts_batchRepayBadDebt_exceeded_pull_limit() public {
-    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
 
     uint256 newAvailableBudget = debtDollarAmount / 2;
 
@@ -257,8 +257,8 @@ contract ClinicStewardV2Test is ClinicStewardV2BaseTest {
     assertTrue(collectorBalanceBefore >= collectorBalanceAfter);
     assertTrue(collectorBalanceBefore - collectorBalanceAfter <= totalDebtToLiquidate);
 
-    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertApproxEqRel(steward.availableBudget(), availableBudget - debtDollarAmount, 0.0001e18);
 
     assertTrue(collectorCollateralBalanceAfter >= collectorCollateralBalanceBefore);
@@ -291,8 +291,8 @@ contract ClinicStewardV2Test is ClinicStewardV2BaseTest {
     assertGe(collectorDebtUnderlyingBalanceAfter, collectorDebtUnderlyingBalanceBefore);
     assertLe(collectorBalanceBefore - collectorBalanceAfter, totalDebtToLiquidate + 1); // account for 1 wei rounding surplus
 
-    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * (totalDebtToLiquidate))
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * (totalDebtToLiquidate)) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertApproxEqAbs(steward.availableBudget(), availableBudget - debtDollarAmount, 0.0001e18);
 
     assertTrue(collectorCollateralBalanceAfter >= collectorCollateralBalanceBefore);
@@ -315,8 +315,8 @@ contract ClinicStewardV2Test is ClinicStewardV2BaseTest {
   }
 
   function test_reverts_batchLiquidate_exceeded_pull_limit() public {
-    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
 
     uint256 newAvailableBudget = debtDollarAmount / 2;
 

--- a/tests/maintenance/ClinicStewardV3.t.sol
+++ b/tests/maintenance/ClinicStewardV3.t.sol
@@ -121,8 +121,8 @@ contract ClinicStewardV3Test is ClinicStewardV3BaseTest {
 
     assertEq(collectorBalanceBefore - collectorBalanceAfter, totalBadDebt);
 
-    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertEq(steward.availableBudget(), availableBudget - debtDollarAmount);
 
     for (uint256 i = 0; i < usersWithBadDebt.length; i++) {
@@ -148,8 +148,8 @@ contract ClinicStewardV3Test is ClinicStewardV3BaseTest {
       100
     );
 
-    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertEq(steward.availableBudget(), availableBudget - debtDollarAmount);
 
     for (uint256 i = 0; i < usersWithBadDebt.length; i++) {
@@ -171,8 +171,8 @@ contract ClinicStewardV3Test is ClinicStewardV3BaseTest {
   }
 
   function test_reverts_batchRepayBadDebt_exceeded_pull_limit() public {
-    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
 
     uint256 newAvailableBudget = debtDollarAmount / 2;
 
@@ -219,8 +219,8 @@ contract ClinicStewardV3Test is ClinicStewardV3BaseTest {
     assertTrue(collectorBalanceBefore >= collectorBalanceAfter);
     assertTrue(collectorBalanceBefore - collectorBalanceAfter <= totalDebtToLiquidate);
 
-    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertEq(steward.availableBudget(), availableBudget - debtDollarAmount);
 
     assertTrue(collectorCollateralBalanceAfter >= collectorCollateralBalanceBefore);
@@ -261,8 +261,8 @@ contract ClinicStewardV3Test is ClinicStewardV3BaseTest {
     assertGe(collectorDebtUnderlyingBalanceAfter, collectorDebtUnderlyingBalanceBefore);
     assertLe(collectorBalanceBefore - collectorBalanceAfter, totalDebtToLiquidate + 1); // account for 1 wei rounding surplus
 
-    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * (totalDebtToLiquidate))
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * (totalDebtToLiquidate)) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertApproxEqAbs(steward.availableBudget(), availableBudget - debtDollarAmount, 1);
 
     assertTrue(collectorCollateralBalanceAfter >= collectorCollateralBalanceBefore);
@@ -293,8 +293,8 @@ contract ClinicStewardV3Test is ClinicStewardV3BaseTest {
   }
 
   function test_reverts_batchLiquidate_exceeded_pull_limit() public {
-    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
 
     uint256 newAvailableBudget = debtDollarAmount / 2;
 

--- a/tests/risk/SvrOracleSteward.t.sol
+++ b/tests/risk/SvrOracleSteward.t.sol
@@ -9,7 +9,9 @@ import {AaveV3Ethereum, AaveV3EthereumAssets} from "aave-address-book/AaveV3Ethe
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {IAccessControl} from "openzeppelin-contracts/contracts/access/IAccessControl.sol";
 import {
-  Ownable, OwnableWithGuardian, IWithGuardian
+  Ownable,
+  OwnableWithGuardian,
+  IWithGuardian
 } from "solidity-utils/contracts/access-control/OwnableWithGuardian.sol";
 import {AggregatorInterface} from "aave-v3-origin/contracts/dependencies/chainlink/AggregatorInterface.sol";
 
@@ -154,8 +156,7 @@ contract SvrOracleStewardBaseTest is Test {
   function test_ifNoGuardian_activateSvrOracle_shouldRevert() external {
     SvrOracleSteward.AssetOracle[] memory configs = new ISvrOracleSteward.AssetOracle[](1);
     configs[0] = ISvrOracleSteward.AssetOracle({
-      asset: AaveV3EthereumAssets.cbBTC_UNDERLYING,
-      svrOracle: 0x77E55306eeDb1F94a4DcFbAa6628ef87586BC651
+      asset: AaveV3EthereumAssets.cbBTC_UNDERLYING, svrOracle: 0x77E55306eeDb1F94a4DcFbAa6628ef87586BC651
     });
     vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(this)));
     steward.enableSvrOracles(configs);


### PR DESCRIPTION
- Add CCTP Bridge Steward, to send USDC from L2 collectors back to Mainnet collector
- Lint code with current forge version (required to pass CI checks)

See https://github.com/TokenLogic-com-au/aave-stewards/pull/7 for reference (internal discussion and review).