### PR TITLE
LayerZero Bridge Steward

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,5 +1,5 @@
 {
   "lib/aave-helpers": {
-    "rev": "2f0f37bebb8b79be47911302e8834c7634458875"
+    "rev": "9350321d2ce927d6e07e5486e1d3abf5a55cd707"
   }
 }

--- a/scripts/DeployOFTBridge.s.sol
+++ b/scripts/DeployOFTBridge.s.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import {GovernanceV3Optimism} from "aave-address-book/GovernanceV3Optimism.sol";
+import {GovernanceV3Polygon} from "aave-address-book/GovernanceV3Polygon.sol";
+import {GovernanceV3Arbitrum} from "aave-address-book/GovernanceV3Arbitrum.sol";
+import {GovernanceV3Plasma} from "aave-address-book/GovernanceV3Plasma.sol";
+import {AaveV3Ethereum} from "aave-address-book/AaveV3Ethereum.sol";
+import {AaveV3Optimism} from "aave-address-book/AaveV3Optimism.sol";
+import {AaveV3Polygon} from "aave-address-book/AaveV3Polygon.sol";
+import {AaveV3Arbitrum} from "aave-address-book/AaveV3Arbitrum.sol";
+import {AaveV3Plasma} from "aave-address-book/AaveV3Plasma.sol";
+import {
+  ArbitrumScript,
+  OptimismScript,
+  PolygonScript,
+  PlasmaScript
+} from "solidity-utils/contracts/utils/ScriptUtils.sol";
+
+import {OFTBridgeSteward} from "src/bridges/oft/OFTBridgeSteward.sol";
+import {OFTConstants} from "src/bridges/oft/OFTConstants.sol";
+
+address constant TOKEN_LOGIC = 0x3765A685a401622C060E5D700D9ad89413363a91;
+bytes32 constant SALT = "Aave Treasury OFT Bridge";
+
+contract DeployOFTArbitrum is ArbitrumScript {
+  function run() external broadcast {
+    new OFTBridgeSteward{salt: SALT}(
+      OFTConstants.ARBITRUM_USDT0_OFT, // USDT0 OFT (OUpgradeable)
+      TOKEN_LOGIC, // owner
+      GovernanceV3Arbitrum.EXECUTOR_LVL_1, // guardian
+      address(AaveV3Arbitrum.COLLECTOR) // collector
+    );
+  }
+}
+
+contract DeployOFTPolygon is PolygonScript {
+  function run() external broadcast {
+    new OFTBridgeSteward{salt: SALT}(
+      OFTConstants.POLYGON_USDT0_OFT, // USDT0 OFT (OUpgradeable)
+      TOKEN_LOGIC, // owner
+      GovernanceV3Polygon.EXECUTOR_LVL_1, // guardian
+      address(AaveV3Polygon.COLLECTOR) // collector
+    );
+  }
+}
+
+contract DeployOFTOptimism is OptimismScript {
+  function run() external broadcast {
+    new OFTBridgeSteward{salt: SALT}(
+      OFTConstants.OPTIMISM_USDT0_OFT, // USDT0 OFT (OUpgradeable)
+      TOKEN_LOGIC, // owner
+      GovernanceV3Optimism.EXECUTOR_LVL_1, // guardian
+      address(AaveV3Optimism.COLLECTOR) // collector
+    );
+  }
+}
+
+contract DeployOFTPlasma is PlasmaScript {
+  function run() external broadcast {
+    new OFTBridgeSteward{salt: SALT}(
+      OFTConstants.PLASMA_USDT0_OFT, // USDT0 OFT (OUpgradeable)
+      TOKEN_LOGIC, // owner
+      GovernanceV3Plasma.EXECUTOR_LVL_1, // guardian
+      address(AaveV3Plasma.COLLECTOR) // collector
+    );
+  }
+}

--- a/src/bridges/oft/OFTBridgeSteward.sol
+++ b/src/bridges/oft/OFTBridgeSteward.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {ICollector} from "aave-address-book/AaveV3.sol";
+import {AaveV3Ethereum} from "aave-address-book/AaveV3Ethereum.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {OwnableWithGuardian} from "solidity-utils/contracts/access-control/OwnableWithGuardian.sol";
+import {RescuableBase, IRescuableBase} from "solidity-utils/contracts/utils/RescuableBase.sol";
+
+import {IOFTBridgeSteward} from "./interfaces/IOFTBridgeSteward.sol";
+import {IOFT, SendParam, MessagingFee, OFTReceipt} from "./interfaces/IOFT.sol";
+import {OFTConstants} from "./OFTConstants.sol";
+
+/// @title OFTBridgeSteward
+/// @author @stevyhacker, jubeira (TokenLogic)
+/// @notice Helper contract to bridge USDT using OFT V2 (LayerZero OFT)
+contract OFTBridgeSteward is OwnableWithGuardian, RescuableBase, IOFTBridgeSteward {
+  using SafeERC20 for IERC20;
+
+  /// @inheritdoc IOFTBridgeSteward
+  uint32 public constant DESTINATION_EID = OFTConstants.ETHEREUM_EID;
+
+  /// @inheritdoc IOFTBridgeSteward
+  address public constant MAINNET_COLLECTOR = address(AaveV3Ethereum.COLLECTOR);
+
+  /// @inheritdoc IOFTBridgeSteward
+  address public immutable OFT_USDT;
+
+  /// @inheritdoc IOFTBridgeSteward
+  /// @dev Assumes `IERC20(USDT).decimals() == IOFT(OFT_USDT).sharedDecimals()`. If they ever differ, OFT
+  ///      will truncate the bridged amount to shared decimals on send and the dust will remain on the
+  ///      steward (recoverable via `rescueToken`). For USDT/USDT0 this is 6 == 6.
+  address public immutable USDT;
+
+  /// @inheritdoc IOFTBridgeSteward
+  address public immutable COLLECTOR;
+
+  /// @param oftUsdt The OFT address for USDT on this chain
+  /// @param initialOwner The initial owner of the contract
+  /// @param initialGuardian The initial guardian of the contract
+  /// @param collector The local Aave Collector that holds the USDT to bridge and receives rescues / LayerZero refunds
+  constructor(address oftUsdt, address initialOwner, address initialGuardian, address collector)
+    OwnableWithGuardian(initialOwner, initialGuardian)
+  {
+    if (oftUsdt == address(0)) revert InvalidZeroAddress();
+    if (initialOwner == address(0)) revert InvalidZeroAddress();
+    if (initialGuardian == address(0)) revert InvalidZeroAddress();
+    if (collector == address(0)) revert InvalidZeroAddress();
+
+    OFT_USDT = oftUsdt;
+    USDT = IOFT(OFT_USDT).token();
+    COLLECTOR = collector;
+  }
+
+  /// @dev Default receive function enabling the contract to accept native tokens for gas fees
+  receive() external payable {}
+
+  /// @inheritdoc IOFTBridgeSteward
+  function bridge(uint256 amount, uint256 minAmountLD, uint256 maxFee) external payable onlyOwnerOrGuardian {
+    if (amount == 0) revert InvalidZeroAmount();
+    if (minAmountLD == 0) revert InvalidZeroAmount();
+
+    (SendParam memory sendParam, MessagingFee memory messagingFee) =
+      _buildSendParamsAndMessagingFee(amount, minAmountLD);
+    uint256 nativeFee = messagingFee.nativeFee;
+
+    if (nativeFee > maxFee) revert MaxFeeExceeded(nativeFee, maxFee);
+    if (address(this).balance < nativeFee) revert InsufficientBalance(address(this).balance, nativeFee);
+
+    ICollector(COLLECTOR).transfer(IERC20(USDT), address(this), amount);
+
+    // Approve OFT to pull USDT and bridge funds to destination chain.
+    // Reset approvals to 0 to ensure no dangling approval persists afterwards for any reason.
+    IERC20(USDT).forceApprove(OFT_USDT, amount);
+    IOFT(OFT_USDT).send{value: nativeFee}(sendParam, messagingFee, COLLECTOR);
+    IERC20(USDT).forceApprove(OFT_USDT, 0);
+
+    emit Bridge(USDT, DESTINATION_EID, MAINNET_COLLECTOR, amount, minAmountLD);
+  }
+
+  /// @inheritdoc IOFTBridgeSteward
+  function rescueToken(address token) external onlyOwnerOrGuardian {
+    _emergencyTokenTransfer(token, COLLECTOR, type(uint256).max);
+  }
+
+  /// @inheritdoc IOFTBridgeSteward
+  function rescueEth() external onlyOwnerOrGuardian {
+    _emergencyEtherTransfer(COLLECTOR, address(this).balance);
+  }
+
+  /// @inheritdoc IOFTBridgeSteward
+  function quoteSendFee(uint256 amount, uint256 minAmountLD) external view returns (uint256) {
+    (, MessagingFee memory messagingFee) = _buildSendParamsAndMessagingFee(amount, minAmountLD);
+    return messagingFee.nativeFee;
+  }
+
+  /// @inheritdoc IOFTBridgeSteward
+  function quoteAmountReceived(uint256 amount) external view returns (uint256) {
+    SendParam memory sendParam = _buildSendParams(amount, 0);
+    (,, OFTReceipt memory receipt) = IOFT(OFT_USDT).quoteOFT(sendParam);
+    return receipt.amountReceivedLD;
+  }
+
+  /// @inheritdoc IRescuableBase
+  function maxRescue(address token) public view override(RescuableBase) returns (uint256) {
+    return IERC20(token).balanceOf(address(this));
+  }
+
+  /// @notice Helper function to build SendParam for a given amount and minAmountLD
+  function _buildSendParams(uint256 amount, uint256 minAmountLD) internal pure returns (SendParam memory) {
+    return SendParam({
+      dstEid: DESTINATION_EID,
+      to: bytes32(uint256(uint160(MAINNET_COLLECTOR))),
+      amountLD: amount,
+      minAmountLD: minAmountLD,
+      extraOptions: new bytes(0),
+      composeMsg: new bytes(0),
+      oftCmd: new bytes(0)
+    });
+  }
+
+  /// @notice Helper function to build SendParam and MessagingFee for a given amount and minAmountLD
+  function _buildSendParamsAndMessagingFee(uint256 amount, uint256 minAmountLD)
+    internal
+    view
+    returns (SendParam memory, MessagingFee memory)
+  {
+    SendParam memory sendParam = _buildSendParams(amount, minAmountLD);
+    MessagingFee memory messagingFee = IOFT(OFT_USDT).quoteSend(sendParam, false);
+
+    return (sendParam, messagingFee);
+  }
+}

--- a/src/bridges/oft/OFTConstants.sol
+++ b/src/bridges/oft/OFTConstants.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title OFT Constants
+/// @notice Constants for USDT0 OFT bridge integration via LayerZero V2
+/// @dev USDT0 supported chains: Ethereum, Arbitrum, Polygon, Optimism, Ink, Plasma
+///      NOT supported: Avalanche, Base (no USDT0 deployment)
+/// @dev Addresses from https://docs.usdt0.to/technical-documentation/developer/usdt0-deployments
+library OFTConstants {
+  // LayerZero V2 Endpoint IDs
+  uint32 internal constant ETHEREUM_EID = 30101;
+  uint32 internal constant POLYGON_EID = 30109;
+  uint32 internal constant ARBITRUM_EID = 30110;
+  uint32 internal constant OPTIMISM_EID = 30111;
+  uint32 internal constant INK_EID = 30339;
+  uint32 internal constant PLASMA_EID = 30383;
+
+  // USDT0 OFT contracts. The steward calls `send()` on the OFT for the chain it's deployed on.
+  // Protocol context: on Ethereum the OFT is OAdapterUpgradeable (locks USDT); on other chains it's
+  // OUpgradeable (burns/mints USDT0). The steward is only deployed on the non-Ethereum side.
+
+  /// @dev https://etherscan.io/address/0x6C96dE32CEa08842dcc4058c14d3aaAD7Fa41dee
+  address internal constant ETHEREUM_USDT0_OFT = 0x6C96dE32CEa08842dcc4058c14d3aaAD7Fa41dee;
+
+  /// @dev https://arbiscan.io/address/0x14E4A1B13bf7F943c8ff7C51fb60FA964A298D92
+  address internal constant ARBITRUM_USDT0_OFT = 0x14E4A1B13bf7F943c8ff7C51fb60FA964A298D92;
+
+  /// @dev https://polygonscan.com/address/0x6BA10300f0DC58B7a1e4c0e41f5daBb7D7829e13
+  address internal constant POLYGON_USDT0_OFT = 0x6BA10300f0DC58B7a1e4c0e41f5daBb7D7829e13;
+
+  /// @dev https://optimistic.etherscan.io/address/0xF03b4d9AC1D5d1E7c4cEf54C2A313b9fe051A0aD
+  address internal constant OPTIMISM_USDT0_OFT = 0xF03b4d9AC1D5d1E7c4cEf54C2A313b9fe051A0aD;
+
+  /// @dev https://explorer.inkonchain.com/address/0x0200C29006150606B650577BBE7B6248F58470c1
+  address internal constant INK_USDT0_OFT = 0x0200C29006150606B650577BBE7B6248F58470c1;
+
+  /// @dev https://plasmascan.to/address/0x02ca37966753bDdDf11216B73B16C1dE756A7CF9
+  address internal constant PLASMA_USDT0_OFT = 0x02ca37966753bDdDf11216B73B16C1dE756A7CF9;
+
+  // USDT / USDT0 ERC20 token addresses. On Ethereum this is native USDT; on other chains it's the
+  // USDT0 token (TetherTokenOFTExtension or equivalent). The steward reads this from `IOFT.token()`
+  // at construction; these constants are kept here for off-chain tooling and tests.
+
+  /// @dev https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7
+  address internal constant ETHEREUM_USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+
+  /// @dev https://arbiscan.io/address/0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9
+  address internal constant ARBITRUM_USDT = 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9;
+
+  /// @dev https://polygonscan.com/address/0xc2132D05D31c914a87C6611C10748AEb04B58e8F
+  address internal constant POLYGON_USDT = 0xc2132D05D31c914a87C6611C10748AEb04B58e8F;
+
+  /// @dev https://optimistic.etherscan.io/address/0x01bFF41798a0BcF287b996046Ca68b395DbC1071
+  address internal constant OPTIMISM_USDT = 0x01bFF41798a0BcF287b996046Ca68b395DbC1071;
+
+  /// @dev https://explorer.inkonchain.com/address/0x0200C29006150606B650577BBE7B6248F58470c1
+  address internal constant INK_USDT = 0x0200C29006150606B650577BBE7B6248F58470c1;
+
+  /// @dev https://plasmascan.to/address/0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb
+  address internal constant PLASMA_USDT = 0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb;
+}

--- a/src/bridges/oft/README.md
+++ b/src/bridges/oft/README.md
@@ -1,0 +1,148 @@
+# OFTBridgeSteward
+
+`OFTBridgeSteward` is an Aave Steward that bridges USDT from a non-Ethereum chain to the Ethereum mainnet Collector using USDT0 OFT (Omnichain Fungible Token) over LayerZero V2. The transfer is 1:1 with no slippage.
+
+The steward is unidirectional: every deployed instance bridges *to* Ethereum mainnet. The destination endpoint and receiver address are immutable, set in the contract's code (see `DESTINATION_EID` and `MAINNET_COLLECTOR`).
+
+## How USDT0 Works
+
+USDT0 is Tether's official cross-chain solution using LayerZero's OFT standard. It enables unified USDT liquidity across chains without wrapped tokens.
+
+### Architecture
+
+- **On Ethereum (destination):** USDT0 uses `OAdapterUpgradeable` to release native USDT on receipt of a LayerZero message. The steward is **not** deployed on Ethereum.
+- **On other chains (source):** USDT0 uses `OUpgradeable` which burns USDT0 on send. The steward is deployed on these chains and calls `send` on the local OFT.
+
+### Key Benefits
+
+- **No Slippage:** 1:1 burn-on-source / release-on-destination mechanism.
+- **Unified Liquidity:** All USDT0 is backed 1:1 by USDT locked on Ethereum.
+- **Dual DVN Security:** Verified by both the LayerZero DVN and the USDT0 DVN.
+
+## Functions
+
+### `bridge(uint256 amount, uint256 minAmountLD, uint256 maxFee)`
+
+Bridges `amount` USDT to the immutable `MAINNET_COLLECTOR` on Ethereum (`DESTINATION_EID`). Restricted to owner or guardian.
+
+- The steward pulls `amount` USDT from the local Collector via `ICollector.transfer`, so it must hold the Collector `FUNDS_ADMIN` role.
+- The native LayerZero fee is paid from the steward's own balance. It can be either pre-funded (use `receive()` or `transfer`) or supplied as `msg.value` on the same call — both add to `address(this).balance`, which is what the contract checks.
+- `minAmountLD` is the slippage floor passed through to the OFT.
+- `maxFee` caps the LayerZero `nativeFee`. The call reverts with `MaxFeeExceeded` if the quoted fee exceeds it. Always quote the fee first and pass a snug `maxFee` to avoid getting front-run by a fee spike.
+- LayerZero refunds any unused fee directly to the local Collector (the refund recipient is set to `COLLECTOR`).
+
+### `quoteSendFee(uint256 amount, uint256 minAmountLD) returns (uint256)`
+
+Returns the native-token fee LayerZero will charge for `bridge(amount, minAmountLD, …)`. Use this to size `maxFee` and the value/balance to fund.
+
+### `quoteAmountReceived(uint256 amount) returns (uint256)`
+
+Returns the amount of USDT the Mainnet Collector will get for an `amount` send (after any OFT-level dust truncation). For USDT0 this equals `amount` (no slippage), but always re-quote on-chain rather than assume.
+
+### `rescueToken(address token)` / `rescueEth()`
+
+Sweeps the steward's full balance of `token` (or ETH) back to the local Collector. Restricted to owner or guardian.
+
+## Usage Pattern
+
+```solidity
+// 1. Quote the expected received amount on Ethereum.
+uint256 expectedReceived = bridge.quoteAmountReceived(amount);
+
+// 2. Quote the LayerZero native fee.
+uint256 fee = bridge.quoteSendFee(amount, expectedReceived);
+
+// 3. Grant the steward FUNDS_ADMIN on the local Collector (one-time).
+IAccessControl(address(collector)).grantRole(
+    ICollector(address(collector)).FUNDS_ADMIN_ROLE(),
+    address(bridge)
+);
+
+// 4. Execute the bridge. Either pre-fund the steward with `fee` wei
+//    of native, or supply it as msg.value on the same call.
+bridge.bridge{value: fee}(amount, expectedReceived, fee);
+```
+
+## Permissions
+
+The contract uses `OwnableWithGuardian`. The owner should be the local network's Level 1 Executor (Aave Governance); the guardian is a trusted ops role.
+
+The steward must also hold the local Collector `FUNDS_ADMIN` role so it can call `ICollector.transfer`. Note that this role is broader than what `bridge()` actually exercises — it grants the steward the ability to move *any* token from the Collector to *any* address. A bug or future extension to the steward could in principle exfiltrate other Collector funds, so the role grant is a trust assumption that should be considered when reviewing changes to the steward.
+
+The owner or guardian can:
+
+- Call `bridge()` to initiate transfers.
+- Call `rescueToken()` / `rescueEth()` to sweep stuck assets back to the local Collector.
+
+Only the owner can:
+
+- Transfer ownership.
+
+There is no allow-list of receivers: `MAINNET_COLLECTOR` is a constant in the contract's code.
+
+## Security Considerations
+
+- **Slippage protection:** `minAmountLD` enforces the floor for tokens received on Ethereum. Quote `quoteAmountReceived` immediately before sending.
+- **Fee protection:** The native fee returned by `quoteSendFee` is a *quote* and can drift between the off-chain quote and on-chain execution — LayerZero's executor uses oracle price feeds for destination gas that refresh periodically (typically on the order of minutes), and DVN fees can also shift. The steward re-quotes inside `bridge` immediately before `IOFT.send` and pays whatever the live fee is, drawing from its own balance. `maxFee` is the caller-supplied ceiling: if the live fee exceeds it the call reverts with `MaxFeeExceeded`, so the steward can never be drained beyond `maxFee` per call. Operational guidance: size `maxFee` as `quoteSendFee * (1 + buffer)` (e.g. `1.1x`); if a call reverts with `MaxFeeExceeded`, re-quote and retry.
+- **Approval hygiene:** The steward `forceApprove`s the OFT for exactly `amount`, then resets to `0` after `send`, so no allowance is left dangling.
+- **Refund routing:** LayerZero's refund recipient is hard-coded to the local `COLLECTOR`, so excess native fee goes back to Aave directly.
+- **Rescue path:** Inherits `RescuableBase`; `maxRescue` returns the steward's full token balance, allowing complete sweep.
+- **Fixed destination/receiver:** `DESTINATION_EID` (Ethereum mainnet) and `MAINNET_COLLECTOR` are constants, removing destination-spoofing surface.
+
+## Retry Mechanism
+
+LayerZero supports retrying messages that fail to execute on the destination chain. Because verification (DVN attestation) is decoupled from execution, an already-verified message can be re-executed by anyone without resending it from the source chain.
+
+### How to Retry
+
+1. **LayerZero Scan UI:** find the failed message at [layerzeroscan.com](https://layerzeroscan.com/) and trigger a retry.
+2. **Direct call:** invoke `lzReceive` on the destination Endpoint contract.
+
+See the [LayerZero debugging documentation](https://docs.layerzero.network/v2/developers/evm/troubleshooting/debugging-messages#retry-message) for details.
+
+## Supported Chains
+
+USDT0 is currently deployed on the chains below. Endpoint IDs / OFT addresses are mirrored in [`OFTConstants.sol`](./OFTConstants.sol).
+
+### Endpoint IDs and OFT Contracts
+
+| Chain    | Role        | Endpoint ID | USDT0 OFT Contract                         | Notes                            |
+| -------- | ----------- | ----------- | ------------------------------------------ | -------------------------------- |
+| Ethereum | Destination | 30101       | 0x6C96dE32CEa08842dcc4058c14d3aaAD7Fa41dee | OAdapterUpgradeable (locks USDT) |
+| Arbitrum | Source      | 30110       | 0x14E4A1B13bf7F943c8ff7C51fb60FA964A298D92 | OUpgradeable                     |
+| Polygon  | Source      | 30109       | 0x6BA10300f0DC58B7a1e4c0e41f5daBb7D7829e13 | OUpgradeable                     |
+| Optimism | Source      | 30111       | 0xF03b4d9AC1D5d1E7c4cEf54C2A313b9fe051A0aD | OUpgradeable                     |
+| Ink      | Source      | 30339       | 0x0200C29006150606B650577BBE7B6248F58470c1 | OUpgradeable (no deploy script)  |
+| Plasma   | Source      | 30383       | 0x02ca37966753bDdDf11216B73B16C1dE756A7CF9 | OUpgradeable                     |
+
+The steward is deployed on each *source* chain. Deployment scripts live in [`scripts/DeployOFTBridge.s.sol`](../../../scripts/DeployOFTBridge.s.sol) and currently cover Arbitrum, Polygon, Optimism, and Plasma.
+
+### USDT Token Addresses
+
+| Chain    | USDT/USDT0 Token                           |
+| -------- | ------------------------------------------ |
+| Ethereum | 0xdAC17F958D2ee523a2206206994597C13D831ec7 |
+| Arbitrum | 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9 |
+| Polygon  | 0xc2132D05D31c914a87C6611C10748AEb04B58e8F |
+| Optimism | 0x01bFF41798a0BcF287b996046Ca68b395DbC1071 |
+| Ink      | 0x0200C29006150606B650577BBE7B6248F58470c1 |
+| Plasma   | 0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb |
+
+### Not Supported
+
+| Chain     | Reason              |
+| --------- | ------------------- |
+| Avalanche | No USDT0 deployment |
+| Base      | No USDT0 deployment |
+
+## Known Limitations
+
+1. **Destination is fixed to Ethereum mainnet.** A new contract deployment is required to bridge to any other chain.
+2. **USDT0 only.** Only USDT transfers within the USDT0 system are supported.
+3. **LayerZero native fee.** A small native-token fee is required for messaging. Quote it with `quoteSendFee` before each call. The quote can drift between off-chain quote-time and on-chain execution; see **Fee protection** above for how `maxFee` bounds the exposure.
+
+## References
+
+- [USDT0 Documentation](https://docs.usdt0.to/)
+- [USDT0 Deployments](https://docs.usdt0.to/technical-documentation/developer/usdt0-deployments)
+- [LayerZero V2 OFT Standard](https://docs.layerzero.network/v2/developers/evm/oft/native-transfer)

--- a/src/bridges/oft/interfaces/IOFT.sol
+++ b/src/bridges/oft/interfaces/IOFT.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @dev Struct representing the fee for LayerZero messaging
+struct MessagingFee {
+  uint256 nativeFee;
+  uint256 lzTokenFee;
+}
+
+/// @dev Struct representing the receipt from LayerZero messaging
+struct MessagingReceipt {
+  bytes32 guid;
+  uint64 nonce;
+  MessagingFee fee;
+}
+
+/// @dev Struct representing token parameters for the OFT send() operation
+struct SendParam {
+  uint32 dstEid;
+  bytes32 to;
+  uint256 amountLD;
+  uint256 minAmountLD;
+  bytes extraOptions;
+  bytes composeMsg;
+  bytes oftCmd;
+}
+
+/// @dev Struct representing OFT limit information
+struct OFTLimit {
+  uint256 minAmountLD;
+  uint256 maxAmountLD;
+}
+
+/// @dev Struct representing OFT receipt information
+struct OFTReceipt {
+  uint256 amountSentLD;
+  uint256 amountReceivedLD;
+}
+
+/// @dev Struct representing OFT fee details
+struct OFTFeeDetail {
+  int256 feeAmountLD;
+  string description;
+}
+
+/// @title IOFT
+/// @dev Interface for the OFT (Omnichain Fungible Token) standard
+/// @dev This specific interface ID is '0x02e49c2c'
+interface IOFT {
+  error InvalidLocalDecimals();
+  error SlippageExceeded(uint256 amountLD, uint256 minAmountLD);
+
+  event OFTSent(
+    bytes32 indexed guid, uint32 dstEid, address indexed fromAddress, uint256 amountSentLD, uint256 amountReceivedLD
+  );
+
+  event OFTReceived(bytes32 indexed guid, uint32 srcEid, address indexed toAddress, uint256 amountReceivedLD);
+
+  /// @notice Retrieves interfaceID and the version of the OFT
+  function oftVersion() external view returns (bytes4 interfaceId, uint64 version);
+
+  /// @notice Retrieves the address of the token associated with the OFT
+  function token() external view returns (address);
+
+  /// @notice Indicates whether the OFT contract requires approval of the 'token()' to send
+  function approvalRequired() external view returns (bool);
+
+  /// @notice Retrieves the shared decimals of the OFT
+  function sharedDecimals() external view returns (uint8);
+
+  /// @notice Provides a quote for OFT-related operations
+  function quoteOFT(SendParam calldata _sendParam)
+    external
+    view
+    returns (OFTLimit memory, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory);
+
+  /// @notice Provides a quote for the send() operation
+  function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory);
+
+  /// @notice Executes the send() operation
+  function send(SendParam calldata _sendParam, MessagingFee calldata _fee, address _refundAddress)
+    external
+    payable
+    returns (MessagingReceipt memory, OFTReceipt memory);
+}

--- a/src/bridges/oft/interfaces/IOFTBridgeSteward.sol
+++ b/src/bridges/oft/interfaces/IOFTBridgeSteward.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IOFTBridgeSteward {
+  /// @dev Thrown when the contract balance is not enough to pay the native fee
+  /// @param contractBalance The current balance of the contract
+  /// @param nativeFee The required native fee for the bridge
+  error InsufficientBalance(uint256 contractBalance, uint256 nativeFee);
+
+  /// @dev Thrown when bridge amount or min amount to receive is zero
+  error InvalidZeroAmount();
+
+  /// @dev Thrown when a zero address is provided
+  error InvalidZeroAddress();
+
+  /// @dev Thrown when the max fee is exceeded when bridging
+  /// @param requiredFee The required native fee for the bridge
+  /// @param maxFee The maximum fee allowed as specified in the bridge call
+  error MaxFeeExceeded(uint256 requiredFee, uint256 maxFee);
+
+  /// @notice Emitted when USDT is bridged to a destination chain
+  /// @param token The token address being bridged
+  /// @param dstEid The destination LayerZero endpoint ID
+  /// @param receiver The receiver address on destination
+  /// @param amount The amount bridged
+  /// @param minAmountLD The slippage floor passed to the OFT (minimum acceptable amount on destination)
+  event Bridge(
+    address indexed token, uint32 indexed dstEid, address indexed receiver, uint256 amount, uint256 minAmountLD
+  );
+
+  /// @notice Bridges USDT to a destination chain using OFT
+  /// @dev Only callable by owner or guardian. Requires contract to hold at least the native fee for the bridge,
+  ///      either paid for in this call or beforehand.
+  ///      The bridged USDT is pulled from the Collector via `ICollector.transfer`, so the steward must hold
+  ///      `FUNDS_ADMIN_ROLE` on the Collector.
+  ///      Any `msg.value` in excess of the LayerZero native fee is retained on the contract and is recoverable
+  ///      via `rescueEth`.
+  ///      The native fee returned by `quoteSendFee` is a quote and may drift between the off-chain quote
+  ///      and on-chain execution (LayerZero executor uses periodically-refreshed oracle price feeds for
+  ///      destination gas). The steward re-quotes inside `bridge` and uses the current on-chain fee;
+  ///      `maxFee` caps that fee and reverts with `MaxFeeExceeded` if the live fee exceeds it.
+  /// @param amount The amount of USDT to bridge
+  /// @param minAmountLD The minimum amount to receive on destination (slippage protection)
+  /// @param maxFee The maximum native fee in ETH wei allowed for the bridge
+  function bridge(uint256 amount, uint256 minAmountLD, uint256 maxFee) external payable;
+
+  /// @notice Rescues the specified token back to the Collector
+  /// @param token The address of the ERC20 token to rescue
+  function rescueToken(address token) external;
+
+  /// @notice Rescues ETH from the contract back to the Collector
+  function rescueEth() external;
+
+  /// @notice Returns Mainnet EID (LayerZero Endpoint ID) for bridging
+  function DESTINATION_EID() external view returns (uint32);
+
+  /// @notice Returns the OFT address for USDT on the deployed chain
+  function OFT_USDT() external view returns (address);
+
+  /// @notice Returns the USDT token address on the deployed chain
+  function USDT() external view returns (address);
+
+  /// @notice Returns the Aave Collector address
+  function COLLECTOR() external view returns (address);
+
+  /// @notice Returns the Mainnet collector address (destination receiver) for bridge transfers
+  function MAINNET_COLLECTOR() external view returns (address);
+
+  /// @notice Quotes the native fee required to bridge USDT
+  /// @param amount The amount of USDT to bridge
+  /// @param minAmountLD The minimum amount to receive on destination
+  /// @return nativeFee The native token fee required for bridging
+  function quoteSendFee(uint256 amount, uint256 minAmountLD) external view returns (uint256);
+
+  /// @notice Quotes the amount of USDT expected to be received on the destination chain
+  /// @param amount The amount of USDT to bridge
+  /// @return amountReceivedLD The amount of USDT expected to be received on the destination chain
+  function quoteAmountReceived(uint256 amount) external view returns (uint256);
+}

--- a/src/finance/MainnetSwapSteward.sol
+++ b/src/finance/MainnetSwapSteward.sol
@@ -231,8 +231,7 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
       appData: bytes32(0)
     });
 
-    if (
-      !COMPOSABLE_COW.singleOrders(
+    if (!COMPOSABLE_COW.singleOrders(
         address(this),
         keccak256(
           abi.encode(
@@ -241,8 +240,7 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
             )
           )
         )
-      )
-    ) revert OrderDoesNotExist();
+      )) revert OrderDoesNotExist();
 
     COMPOSABLE_COW.remove(
       keccak256(
@@ -370,9 +368,10 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
 
     IERC20(fromToken).safeIncreaseAllowance(milkman, amount);
 
-    IMilkman(milkman).requestSwapExactTokensForTokens(
-      amount, IERC20(fromToken), IERC20(toToken), recipient, bytes32(0), _priceChecker, priceCheckerData
-    );
+    IMilkman(milkman)
+      .requestSwapExactTokensForTokens(
+        amount, IERC20(fromToken), IERC20(toToken), recipient, bytes32(0), _priceChecker, priceCheckerData
+      );
   }
 
   /// @notice Internal function that handles swap cancellations
@@ -392,9 +391,8 @@ contract MainnetSwapSteward is IMainnetSwapSteward, OwnableWithGuardian, Multica
   ) internal {
     uint256 balanceBefore = IERC20(fromToken).balanceOf(address(this));
 
-    IMilkman(tradeMilkman).cancelSwap(
-      amount, IERC20(fromToken), IERC20(toToken), COLLECTOR, bytes32(0), _priceChecker, priceCheckerData
-    );
+    IMilkman(tradeMilkman)
+      .cancelSwap(amount, IERC20(fromToken), IERC20(toToken), COLLECTOR, bytes32(0), _priceChecker, priceCheckerData);
 
     uint256 balanceDiff = IERC20(fromToken).balanceOf(address(this)) - balanceBefore;
 

--- a/src/maintenance/ClinicStewardBase.sol
+++ b/src/maintenance/ClinicStewardBase.sol
@@ -152,7 +152,8 @@ abstract contract ClinicStewardBase is IClinicSteward, RescuableBase, Multicall,
         borrower: users[i],
         debtToCover: type(uint256).max,
         receiveAToken: true
-      }) {} catch {
+      }) {}
+      catch {
         maxDebtAmount -= amounts[i];
       }
     }
@@ -235,10 +236,7 @@ abstract contract ClinicStewardBase is IClinicSteward, RescuableBase, Multicall,
 
     if (dollarAmount > oldAvailableBudget) {
       revert AvailableBudgetExceeded({
-        asset: asset,
-        assetAmount: amount,
-        dollarAmount: dollarAmount,
-        availableBudget: oldAvailableBudget
+        asset: asset, assetAmount: amount, dollarAmount: dollarAmount, availableBudget: oldAvailableBudget
       });
     }
 

--- a/src/maintenance/ClinicStewardV2.sol
+++ b/src/maintenance/ClinicStewardV2.sol
@@ -41,11 +41,11 @@ contract ClinicStewardV2 is ClinicStewardBase {
     if (block.chainid == 1 || block.chainid == 137) {
       // @note In Aave V2 Polygon, Ethereum Core and AMM an oracle has ETH as a base currency
       if (block.chainid == 1) {
-        // `ChainlinkEthereum.ETH_USD` has 8 decimals
-        return priceFromOracle * uint256(AggregatorInterface(ChainlinkEthereum.ETH_USD).latestAnswer()) / 1e18;
+        // `ChainlinkEthereum.ETH__USD` has 8 decimals
+        return priceFromOracle * uint256(AggregatorInterface(ChainlinkEthereum.ETH__USD).latestAnswer()) / 1e18;
       } else {
-        // `ChainlinkPolygon.ETH_USD` has 8 decimals
-        return priceFromOracle * uint256(AggregatorInterface(ChainlinkPolygon.ETH_USD).latestAnswer()) / 1e18;
+        // `ChainlinkPolygon.ETH__USD` has 8 decimals
+        return priceFromOracle * uint256(AggregatorInterface(ChainlinkPolygon.ETH__USD).latestAnswer()) / 1e18;
       }
     } else {
       return priceFromOracle;

--- a/tests/bridges/oft/OFTBridgeForkTest.t.sol
+++ b/tests/bridges/oft/OFTBridgeForkTest.t.sol
@@ -1,0 +1,467 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IAccessControl} from "openzeppelin-contracts/contracts/access/IAccessControl.sol";
+import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
+import {GovernanceV3Ethereum} from "aave-address-book/GovernanceV3Ethereum.sol";
+import {AaveV3Ethereum} from "aave-address-book/AaveV3Ethereum.sol";
+import {AaveV3Arbitrum} from "aave-address-book/AaveV3Arbitrum.sol";
+import {IWithGuardian} from "solidity-utils/contracts/access-control/interfaces/IWithGuardian.sol";
+
+import {ICollector} from "aave-address-book/AaveV3.sol";
+
+import {OFTConstants} from "src/bridges/oft/OFTConstants.sol";
+import {OFTBridgeSteward} from "src/bridges/oft/OFTBridgeSteward.sol";
+import {IOFT} from "src/bridges/oft/interfaces/IOFT.sol";
+import {IOFTBridgeSteward} from "src/bridges/oft/interfaces/IOFTBridgeSteward.sol";
+
+/**
+ * @title OFTBridgeForkTestBase
+ * @notice Fork tests for USDT0 OFT bridge via LayerZero V2.
+ * @dev OFTBridgeSteward bridges *to* Ethereum (DESTINATION_EID is fixed to mainnet),
+ *      so end-to-end bridging is tested on the Arbitrum fork. The mainnet instance
+ *      only exercises constructor/immutable, ownership, and rescue paths.
+ */
+contract OFTBridgeForkTestBase is Test {
+  uint256 public constant LARGE_BRIDGE_AMOUNT = 10_000_000e6; // 10 million USDT
+
+  uint256 public mainnetFork;
+  uint256 public arbitrumFork;
+
+  address public owner = makeAddr("owner");
+  address public guardian = makeAddr("guardian");
+  address public mainnetCollector = address(AaveV3Ethereum.COLLECTOR);
+
+  OFTBridgeSteward public mainnetBridge;
+  OFTBridgeSteward public arbitrumBridge;
+
+  function setUp() public virtual {
+    arbitrumFork = vm.createSelectFork(vm.rpcUrl("mainnet"));
+
+    mainnetBridge =
+      new OFTBridgeSteward(OFTConstants.ETHEREUM_USDT0_OFT, owner, guardian, address(AaveV3Ethereum.COLLECTOR));
+  }
+
+  /// @dev Spins up an Arbitrum fork, deploys an `arbitrumBridge`, and optionally
+  ///      grants FUNDS_ADMIN, deals USDT to the local Collector, and pre-funds the steward.
+  function _setUpArbitrumBridge(bool grantFundsAdminRole, uint256 dealUsdtToCollector, uint256 dealNativeToBridge)
+    internal
+  {
+    arbitrumFork = vm.createSelectFork(vm.rpcUrl("arbitrum"));
+
+    arbitrumBridge =
+      new OFTBridgeSteward(OFTConstants.ARBITRUM_USDT0_OFT, owner, guardian, address(AaveV3Arbitrum.COLLECTOR));
+
+    if (grantFundsAdminRole) {
+      bytes32 fundsAdminRole = AaveV3Arbitrum.COLLECTOR.FUNDS_ADMIN_ROLE();
+      vm.prank(AaveV3Arbitrum.ACL_ADMIN);
+      IAccessControl(address(AaveV3Arbitrum.COLLECTOR)).grantRole(fundsAdminRole, address(arbitrumBridge));
+    }
+
+    if (dealUsdtToCollector > 0) {
+      deal(OFTConstants.ARBITRUM_USDT, address(AaveV3Arbitrum.COLLECTOR), dealUsdtToCollector);
+    }
+
+    if (dealNativeToBridge > 0) {
+      vm.deal(address(arbitrumBridge), dealNativeToBridge);
+    }
+  }
+}
+
+/// @notice Quote tests for Arbitrum -> Ethereum USDT bridging via USDT0 OFT.
+contract QuoteArbitrumToEthereumTest is OFTBridgeForkTestBase {
+  function setUp() public override {
+    arbitrumFork = vm.createSelectFork(vm.rpcUrl("arbitrum"));
+
+    arbitrumBridge =
+      new OFTBridgeSteward(OFTConstants.ARBITRUM_USDT0_OFT, owner, guardian, address(AaveV3Arbitrum.COLLECTOR));
+  }
+
+  function test_quoteSendFee_arbitrumToEthereum() public view {
+    uint256 fee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
+    assertGt(fee, 0, "Fee should be greater than 0");
+  }
+
+  function test_quoteAmountReceived_arbitrumToEthereum() public view {
+    uint256 amountReceived = arbitrumBridge.quoteAmountReceived(LARGE_BRIDGE_AMOUNT);
+    assertEq(amountReceived, LARGE_BRIDGE_AMOUNT, "OFT should have no slippage");
+  }
+
+  function test_quote_arbitrumToEthereum_10MillionUSDT() public view {
+    uint256 expectedReceived = arbitrumBridge.quoteAmountReceived(LARGE_BRIDGE_AMOUNT);
+    assertEq(expectedReceived, LARGE_BRIDGE_AMOUNT, "OFT should have no slippage");
+
+    uint256 fee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
+    assertGt(fee, 0, "Fee should be greater than 0");
+  }
+}
+
+/// @notice Tests for Arbitrum -> Ethereum USDT bridging via USDT0 OFT.
+contract BridgeArbitrumToEthereumTest is OFTBridgeForkTestBase {
+  function setUp() public override {
+    arbitrumFork = vm.createSelectFork(vm.rpcUrl("arbitrum"));
+
+    arbitrumBridge =
+      new OFTBridgeSteward(OFTConstants.ARBITRUM_USDT0_OFT, owner, guardian, address(AaveV3Arbitrum.COLLECTOR));
+
+    bytes32 fundsAdminRole = AaveV3Arbitrum.COLLECTOR.FUNDS_ADMIN_ROLE();
+    vm.prank(AaveV3Arbitrum.ACL_ADMIN);
+    IAccessControl(address(AaveV3Arbitrum.COLLECTOR)).grantRole(fundsAdminRole, address(arbitrumBridge));
+  }
+
+  function test_bridge_arbitrumToEthereum_10MillionUSDT() public {
+    deal(OFTConstants.ARBITRUM_USDT, address(AaveV3Arbitrum.COLLECTOR), LARGE_BRIDGE_AMOUNT);
+    assertEq(
+      IERC20(OFTConstants.ARBITRUM_USDT).balanceOf(address(AaveV3Arbitrum.COLLECTOR)),
+      LARGE_BRIDGE_AMOUNT,
+      "Collector should have USDT"
+    );
+
+    uint256 expectedReceived = arbitrumBridge.quoteAmountReceived(LARGE_BRIDGE_AMOUNT);
+    assertEq(expectedReceived, LARGE_BRIDGE_AMOUNT, "OFT should have no slippage");
+
+    uint256 fee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
+    vm.deal(address(arbitrumBridge), fee + 1 ether);
+    uint256 totalSupplyBefore = IERC20(OFTConstants.ARBITRUM_USDT).totalSupply();
+
+    vm.expectEmit(true, true, true, true, address(arbitrumBridge));
+    emit IOFTBridgeSteward.Bridge(
+      OFTConstants.ARBITRUM_USDT, OFTConstants.ETHEREUM_EID, mainnetCollector, LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT
+    );
+
+    vm.prank(owner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, fee);
+
+    assertEq(
+      IERC20(OFTConstants.ARBITRUM_USDT).balanceOf(address(AaveV3Arbitrum.COLLECTOR)),
+      0,
+      "Collector should have 0 USDT after bridging"
+    );
+    assertEq(
+      IERC20(OFTConstants.ARBITRUM_USDT).balanceOf(address(arbitrumBridge)),
+      0,
+      "Bridge should have 0 USDT after bridging"
+    );
+    assertEq(
+      IERC20(OFTConstants.ARBITRUM_USDT).totalSupply(),
+      totalSupplyBefore - LARGE_BRIDGE_AMOUNT,
+      "USDT should be burned on Arbitrum"
+    );
+    assertEq(
+      IERC20(OFTConstants.ARBITRUM_USDT).allowance(address(arbitrumBridge), OFTConstants.ARBITRUM_USDT0_OFT),
+      0,
+      "Allowance between bridge and OFT should be 0"
+    );
+  }
+}
+
+contract RescueTokenTest is OFTBridgeForkTestBase {
+  function test_rescueToken() public {
+    uint256 amount = 1_000_000e6;
+    deal(OFTConstants.ETHEREUM_USDT, address(mainnetBridge), amount);
+
+    uint256 collectorBalanceBefore = IERC20(OFTConstants.ETHEREUM_USDT).balanceOf(address(AaveV3Ethereum.COLLECTOR));
+
+    vm.prank(owner);
+    mainnetBridge.rescueToken(OFTConstants.ETHEREUM_USDT);
+
+    assertEq(
+      IERC20(OFTConstants.ETHEREUM_USDT).balanceOf(address(AaveV3Ethereum.COLLECTOR)),
+      collectorBalanceBefore + amount,
+      "Collector should receive tokens"
+    );
+    assertEq(IERC20(OFTConstants.ETHEREUM_USDT).balanceOf(address(mainnetBridge)), 0, "Bridge should have 0 balance");
+  }
+}
+
+/// @notice Tests for constructor and immutable values.
+contract ConstructorAndImmutablesTest is OFTBridgeForkTestBase {
+  function test_constructor_setsImmutables() public view {
+    assertEq(mainnetBridge.OFT_USDT(), OFTConstants.ETHEREUM_USDT0_OFT, "OFT_USDT should be set correctly");
+    assertEq(mainnetBridge.USDT(), OFTConstants.ETHEREUM_USDT, "USDT should be set correctly");
+    assertEq(mainnetBridge.owner(), owner, "Owner should be set correctly");
+    assertEq(mainnetBridge.guardian(), guardian, "Guardian should be set correctly");
+    assertEq(mainnetBridge.COLLECTOR(), address(AaveV3Ethereum.COLLECTOR), "Collector should be set correctly");
+    assertEq(mainnetBridge.MAINNET_COLLECTOR(), mainnetCollector, "Mainnet collector should be set correctly");
+  }
+
+  function test_constructor_arbitrumBridge() public {
+    arbitrumFork = vm.createSelectFork(vm.rpcUrl("arbitrum"));
+
+    arbitrumBridge =
+      new OFTBridgeSteward(OFTConstants.ARBITRUM_USDT0_OFT, owner, guardian, address(AaveV3Arbitrum.COLLECTOR));
+
+    assertEq(arbitrumBridge.OFT_USDT(), OFTConstants.ARBITRUM_USDT0_OFT, "OFT_USDT should be set correctly");
+    assertEq(arbitrumBridge.USDT(), OFTConstants.ARBITRUM_USDT, "USDT should be set correctly");
+    assertEq(arbitrumBridge.owner(), owner, "Owner should be set correctly");
+    assertEq(arbitrumBridge.guardian(), guardian, "Guardian should be set correctly");
+    assertEq(arbitrumBridge.COLLECTOR(), address(AaveV3Arbitrum.COLLECTOR), "Collector should be set correctly");
+    assertEq(
+      arbitrumBridge.MAINNET_COLLECTOR(), address(AaveV3Ethereum.COLLECTOR), "Mainnet collector should be set correctly"
+    );
+  }
+
+  function test_constructor_revertsIf_zeroGuardian() public {
+    vm.expectRevert(IOFTBridgeSteward.InvalidZeroAddress.selector);
+    new OFTBridgeSteward(OFTConstants.ETHEREUM_USDT0_OFT, owner, address(0), address(AaveV3Ethereum.COLLECTOR));
+  }
+
+  function test_constructor_revertsIf_zeroCollector() public {
+    vm.expectRevert(IOFTBridgeSteward.InvalidZeroAddress.selector);
+    new OFTBridgeSteward(OFTConstants.ETHEREUM_USDT0_OFT, owner, guardian, address(0));
+  }
+
+  function test_constructor_revertsIf_zeroOft() public {
+    vm.expectRevert(IOFTBridgeSteward.InvalidZeroAddress.selector);
+    new OFTBridgeSteward(address(0), owner, guardian, address(AaveV3Ethereum.COLLECTOR));
+  }
+}
+
+/// @notice Tests for receive function and native token handling.
+contract ReceiveFunctionTest is OFTBridgeForkTestBase {
+  function test_receive_acceptsNativeTokens() public {
+    uint256 balanceBefore = address(mainnetBridge).balance;
+
+    address sender = makeAddr("sender");
+    vm.deal(sender, 10 ether);
+
+    vm.prank(sender);
+    (bool success,) = address(mainnetBridge).call{value: 1 ether}("");
+
+    assertTrue(success, "Should accept native tokens");
+    assertEq(address(mainnetBridge).balance, balanceBefore + 1 ether, "Balance should increase");
+  }
+}
+
+/// @notice Tests for rescue functionality.
+contract RescuableTest is OFTBridgeForkTestBase {
+  function test_maxRescue_returnsBridgeBalance() public {
+    uint256 amount = 2_500e6;
+    deal(OFTConstants.ETHEREUM_USDT, address(mainnetBridge), amount);
+
+    assertEq(
+      mainnetBridge.maxRescue(OFTConstants.ETHEREUM_USDT), amount, "maxRescue should return bridge token balance"
+    );
+  }
+
+  function test_rescueToken_revertsIf_notOwnerOrGuardian() public {
+    address notOwner = makeAddr("not-owner");
+    uint256 amount = 1_000e6;
+    deal(OFTConstants.ETHEREUM_USDT, address(mainnetBridge), amount);
+
+    vm.prank(notOwner);
+    vm.expectRevert(abi.encodeWithSelector(IWithGuardian.OnlyGuardianOrOwnerInvalidCaller.selector, notOwner));
+    mainnetBridge.rescueToken(OFTConstants.ETHEREUM_USDT);
+  }
+
+  function test_rescueEth() public {
+    uint256 ethAmount = 5 ether;
+    vm.deal(address(mainnetBridge), ethAmount);
+
+    uint256 collectorBalanceBefore = address(AaveV3Ethereum.COLLECTOR).balance;
+
+    vm.prank(owner);
+    mainnetBridge.rescueEth();
+
+    assertEq(
+      address(AaveV3Ethereum.COLLECTOR).balance, collectorBalanceBefore + ethAmount, "Collector should receive ETH"
+    );
+    assertEq(address(mainnetBridge).balance, 0, "Bridge should have 0 ETH balance");
+  }
+}
+
+/// @notice bridge() revert paths: maxFee cap, native balance, zero args, OFT-side slippage.
+contract BridgeRevertsTest is OFTBridgeForkTestBase {
+  uint256 public quotedFee;
+
+  function setUp() public override {
+    _setUpArbitrumBridge({grantFundsAdminRole: true, dealUsdtToCollector: LARGE_BRIDGE_AMOUNT, dealNativeToBridge: 0});
+    quotedFee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
+  }
+
+  function test_bridge_revertsIf_maxFeeExceeded() public {
+    vm.expectRevert(abi.encodeWithSelector(IOFTBridgeSteward.MaxFeeExceeded.selector, quotedFee, quotedFee - 1));
+    vm.prank(owner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, quotedFee - 1);
+  }
+
+  function test_bridge_revertsIf_insufficientBalance() public {
+    // Steward deliberately not funded.
+    vm.expectRevert(abi.encodeWithSelector(IOFTBridgeSteward.InsufficientBalance.selector, 0, quotedFee));
+    vm.prank(owner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, type(uint256).max);
+  }
+
+  function test_bridge_revertsIf_zeroAmount() public {
+    vm.expectRevert(IOFTBridgeSteward.InvalidZeroAmount.selector);
+    vm.prank(owner);
+    arbitrumBridge.bridge(0, 1, type(uint256).max);
+  }
+
+  function test_bridge_revertsIf_zeroMinAmountLD() public {
+    vm.expectRevert(IOFTBridgeSteward.InvalidZeroAmount.selector);
+    vm.prank(owner);
+    arbitrumBridge.bridge(1, 0, type(uint256).max);
+  }
+
+  function test_bridge_revertsIf_slippageExceeded() public {
+    vm.deal(address(arbitrumBridge), quotedFee);
+    vm.expectRevert(
+      abi.encodeWithSelector(IOFT.SlippageExceeded.selector, LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT + 1)
+    );
+    vm.prank(owner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT + 1, type(uint256).max);
+  }
+}
+
+/// @notice bridge() access control: non-owner/guardian rejection and the guardian happy path.
+contract BridgeAccessControlTest is OFTBridgeForkTestBase {
+  uint256 public quotedFee;
+
+  function setUp() public override {
+    _setUpArbitrumBridge({grantFundsAdminRole: true, dealUsdtToCollector: LARGE_BRIDGE_AMOUNT, dealNativeToBridge: 0});
+    quotedFee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
+    vm.deal(address(arbitrumBridge), quotedFee);
+  }
+
+  function test_bridge_revertsIf_notOwnerOrGuardian() public {
+    address notOwner = makeAddr("not-owner");
+    vm.expectRevert(abi.encodeWithSelector(IWithGuardian.OnlyGuardianOrOwnerInvalidCaller.selector, notOwner));
+    vm.prank(notOwner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, quotedFee);
+  }
+
+  function test_bridge_byGuardian_succeeds() public {
+    uint256 totalSupplyBefore = IERC20(OFTConstants.ARBITRUM_USDT).totalSupply();
+
+    vm.expectEmit(true, true, true, true, address(arbitrumBridge));
+    emit IOFTBridgeSteward.Bridge(
+      OFTConstants.ARBITRUM_USDT,
+      OFTConstants.ETHEREUM_EID,
+      address(AaveV3Ethereum.COLLECTOR),
+      LARGE_BRIDGE_AMOUNT,
+      LARGE_BRIDGE_AMOUNT
+    );
+
+    vm.prank(guardian);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, quotedFee);
+
+    assertEq(
+      IERC20(OFTConstants.ARBITRUM_USDT).totalSupply(), totalSupplyBefore - LARGE_BRIDGE_AMOUNT, "USDT should be burned"
+    );
+  }
+}
+
+/// @notice bridge() reverts inside ICollector.transfer when the steward lacks FUNDS_ADMIN.
+contract BridgeMissingRoleTest is OFTBridgeForkTestBase {
+  uint256 public quotedFee;
+
+  function setUp() public override {
+    _setUpArbitrumBridge({grantFundsAdminRole: false, dealUsdtToCollector: LARGE_BRIDGE_AMOUNT, dealNativeToBridge: 0});
+    quotedFee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
+    vm.deal(address(arbitrumBridge), quotedFee);
+  }
+
+  function test_bridge_revertsIf_noFundsAdminRole() public {
+    vm.expectRevert(ICollector.OnlyFundsAdmin.selector);
+    vm.prank(owner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, quotedFee);
+  }
+}
+
+/// @notice Ownership lifecycle (Ownable from OZ via OwnableWithGuardian).
+contract TransferOwnershipTest is OFTBridgeForkTestBase {
+  function test_transferOwnership() public {
+    address newOwner = GovernanceV3Ethereum.EXECUTOR_LVL_1;
+
+    vm.prank(owner);
+    mainnetBridge.transferOwnership(newOwner);
+
+    assertEq(mainnetBridge.owner(), newOwner, "Ownership should be transferred");
+  }
+
+  function test_transferOwnership_revertsIf_notOwner() public {
+    address notOwner = makeAddr("not-owner");
+    address newOwner = makeAddr("new-owner");
+
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, notOwner));
+    vm.prank(notOwner);
+    mainnetBridge.transferOwnership(newOwner);
+  }
+
+  function test_renounceOwnership() public {
+    vm.prank(owner);
+    mainnetBridge.renounceOwnership();
+
+    assertEq(mainnetBridge.owner(), address(0), "Owner should be zero address");
+  }
+}
+
+/// @notice rescueEth access control: non-owner/guardian rejection and the guardian happy path.
+contract RescueEthAccessControlTest is OFTBridgeForkTestBase {
+  uint256 public constant ETH_AMOUNT = 5 ether;
+
+  function setUp() public override {
+    super.setUp();
+    vm.deal(address(mainnetBridge), ETH_AMOUNT);
+  }
+
+  function test_rescueEth_revertsIf_notOwnerOrGuardian() public {
+    address notOwner = makeAddr("not-owner");
+    vm.expectRevert(abi.encodeWithSelector(IWithGuardian.OnlyGuardianOrOwnerInvalidCaller.selector, notOwner));
+    vm.prank(notOwner);
+    mainnetBridge.rescueEth();
+  }
+
+  function test_rescueEth_byGuardian_succeeds() public {
+    uint256 collectorBalanceBefore = address(AaveV3Ethereum.COLLECTOR).balance;
+
+    vm.prank(guardian);
+    mainnetBridge.rescueEth();
+
+    assertEq(
+      address(AaveV3Ethereum.COLLECTOR).balance, collectorBalanceBefore + ETH_AMOUNT, "Collector should receive ETH"
+    );
+    assertEq(address(mainnetBridge).balance, 0, "Bridge should have 0 ETH balance");
+  }
+}
+
+/// @notice Funding paths for the LayerZero native fee: pre-fund vs. msg.value, and excess retention.
+contract BridgeNativeFeePathsTest is OFTBridgeForkTestBase {
+  uint256 public quotedFee;
+
+  function setUp() public override {
+    _setUpArbitrumBridge({grantFundsAdminRole: true, dealUsdtToCollector: LARGE_BRIDGE_AMOUNT, dealNativeToBridge: 0});
+    quotedFee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
+  }
+
+  function test_bridge_preFunded_zeroValue() public {
+    vm.deal(address(arbitrumBridge), quotedFee);
+
+    vm.prank(owner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, quotedFee);
+
+    assertEq(address(arbitrumBridge).balance, 0, "Steward should have spent its native");
+  }
+
+  function test_bridge_msgValue_only() public {
+    vm.deal(owner, quotedFee);
+
+    vm.prank(owner);
+    arbitrumBridge.bridge{value: quotedFee}(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, quotedFee);
+
+    assertEq(address(arbitrumBridge).balance, 0, "Steward should have spent the msg.value");
+  }
+
+  function test_bridge_excessPreFunding_remainsOnSteward() public {
+    uint256 buffer = 1 ether;
+    vm.deal(address(arbitrumBridge), quotedFee + buffer);
+
+    vm.prank(owner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, quotedFee);
+
+    assertEq(address(arbitrumBridge).balance, buffer, "Excess pre-funding should remain on steward");
+  }
+}

--- a/tests/finance/MainnetSwapSteward.t.sol
+++ b/tests/finance/MainnetSwapSteward.t.sol
@@ -792,9 +792,8 @@ contract CancelTWAPSwapTest is MainnetSwapStewardTest {
 
     // Creating this order yields the following order hash:
     // 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    bool orderExists = IComposableCow(COMPOSABLE_COW).singleOrders(
-      address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    );
+    bool orderExists = IComposableCow(COMPOSABLE_COW)
+      .singleOrders(address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28);
 
     assertEq(steward.tokenBudget(AaveV3EthereumAssets.USDC_UNDERLYING), budgetBefore - (amount * numParts));
     assertTrue(orderExists, "Order does not exist");
@@ -812,9 +811,8 @@ contract CancelTWAPSwapTest is MainnetSwapStewardTest {
       0
     );
 
-    orderExists = IComposableCow(COMPOSABLE_COW).singleOrders(
-      address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    );
+    orderExists = IComposableCow(COMPOSABLE_COW)
+      .singleOrders(address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28);
     assertTrue(orderExists, "Order incorrectly removed");
     vm.stopPrank();
   }
@@ -846,9 +844,8 @@ contract CancelTWAPSwapTest is MainnetSwapStewardTest {
 
     // Creating this order yields the following order hash:
     // 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    bool orderExists = IComposableCow(COMPOSABLE_COW).singleOrders(
-      address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    );
+    bool orderExists = IComposableCow(COMPOSABLE_COW)
+      .singleOrders(address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28);
 
     assertEq(steward.tokenBudget(AaveV3EthereumAssets.USDC_UNDERLYING), budgetBefore - (amount * numParts));
     assertTrue(orderExists, "Order does not exist");
@@ -868,9 +865,8 @@ contract CancelTWAPSwapTest is MainnetSwapStewardTest {
       0
     );
 
-    orderExists = IComposableCow(COMPOSABLE_COW).singleOrders(
-      address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    );
+    orderExists = IComposableCow(COMPOSABLE_COW)
+      .singleOrders(address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28);
 
     // Budget does not increase
     assertEq(steward.tokenBudget(AaveV3EthereumAssets.USDC_UNDERLYING), budgetBefore - (amount * numParts));
@@ -905,9 +901,8 @@ contract CancelTWAPSwapTest is MainnetSwapStewardTest {
 
     // Creating this order yields the following order hash:
     // 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    bool orderExists = IComposableCow(COMPOSABLE_COW).singleOrders(
-      address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    );
+    bool orderExists = IComposableCow(COMPOSABLE_COW)
+      .singleOrders(address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28);
 
     assertEq(steward.tokenBudget(AaveV3EthereumAssets.USDC_UNDERLYING), budgetBefore - (amount * numParts));
     assertTrue(orderExists, "Order does not exist");
@@ -934,9 +929,8 @@ contract CancelTWAPSwapTest is MainnetSwapStewardTest {
       1
     );
 
-    orderExists = IComposableCow(COMPOSABLE_COW).singleOrders(
-      address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28
-    );
+    orderExists = IComposableCow(COMPOSABLE_COW)
+      .singleOrders(address(steward), 0xa1cd0126c63d96b3d82ba666eb592348a132bfa3dbf6028168fb72df14a3fe28);
 
     // Budget does not increase
     assertEq(steward.tokenBudget(AaveV3EthereumAssets.USDC_UNDERLYING), budgetBefore - (amount * numParts));

--- a/tests/finance/RewardsSteward.t.sol
+++ b/tests/finance/RewardsSteward.t.sol
@@ -30,9 +30,8 @@ contract RewardsStewardTest is Test {
     steward = new RewardsSteward(address(AaveV3Ethereum.COLLECTOR), AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER);
 
     vm.prank(AaveV3Ethereum.EMISSION_MANAGER);
-    IRewardsController(AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER).setClaimer(
-      address(AaveV3Ethereum.COLLECTOR), address(steward)
-    );
+    IRewardsController(AaveV3Ethereum.DEFAULT_INCENTIVES_CONTROLLER)
+      .setClaimer(address(AaveV3Ethereum.COLLECTOR), address(steward));
   }
 }
 

--- a/tests/maintenance/ClinicStewardV2.t.sol
+++ b/tests/maintenance/ClinicStewardV2.t.sol
@@ -168,8 +168,8 @@ contract ClinicStewardV2Test is ClinicStewardV2BaseTest {
 
     assertEq(collectorBalanceBefore - collectorBalanceAfter, totalBadDebt);
 
-    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertApproxEqRel(steward.availableBudget(), availableBudget - debtDollarAmount, 0.0001e18);
 
     for (uint256 i = 0; i < usersWithBadDebt.length; i++) {
@@ -195,8 +195,8 @@ contract ClinicStewardV2Test is ClinicStewardV2BaseTest {
       100
     );
 
-    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertApproxEqRel(steward.availableBudget(), availableBudget - debtDollarAmount, 0.0001e18);
 
     for (uint256 i = 0; i < usersWithBadDebt.length; i++) {
@@ -218,8 +218,8 @@ contract ClinicStewardV2Test is ClinicStewardV2BaseTest {
   }
 
   function test_reverts_batchRepayBadDebt_exceeded_pull_limit() public {
-    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
 
     uint256 newAvailableBudget = debtDollarAmount / 2;
 
@@ -257,8 +257,8 @@ contract ClinicStewardV2Test is ClinicStewardV2BaseTest {
     assertTrue(collectorBalanceBefore >= collectorBalanceAfter);
     assertTrue(collectorBalanceBefore - collectorBalanceAfter <= totalDebtToLiquidate);
 
-    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertApproxEqRel(steward.availableBudget(), availableBudget - debtDollarAmount, 0.0001e18);
 
     assertTrue(collectorCollateralBalanceAfter >= collectorCollateralBalanceBefore);
@@ -291,8 +291,8 @@ contract ClinicStewardV2Test is ClinicStewardV2BaseTest {
     assertGe(collectorDebtUnderlyingBalanceAfter, collectorDebtUnderlyingBalanceBefore);
     assertLe(collectorBalanceBefore - collectorBalanceAfter, totalDebtToLiquidate + 1); // account for 1 wei rounding surplus
 
-    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * (totalDebtToLiquidate))
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * (totalDebtToLiquidate)) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertApproxEqAbs(steward.availableBudget(), availableBudget - debtDollarAmount, 0.0001e18);
 
     assertTrue(collectorCollateralBalanceAfter >= collectorCollateralBalanceBefore);
@@ -315,8 +315,8 @@ contract ClinicStewardV2Test is ClinicStewardV2BaseTest {
   }
 
   function test_reverts_batchLiquidate_exceeded_pull_limit() public {
-    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Ethereum.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
 
     uint256 newAvailableBudget = debtDollarAmount / 2;
 

--- a/tests/maintenance/ClinicStewardV3.t.sol
+++ b/tests/maintenance/ClinicStewardV3.t.sol
@@ -121,8 +121,8 @@ contract ClinicStewardV3Test is ClinicStewardV3BaseTest {
 
     assertEq(collectorBalanceBefore - collectorBalanceAfter, totalBadDebt);
 
-    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertEq(steward.availableBudget(), availableBudget - debtDollarAmount);
 
     for (uint256 i = 0; i < usersWithBadDebt.length; i++) {
@@ -148,8 +148,8 @@ contract ClinicStewardV3Test is ClinicStewardV3BaseTest {
       100
     );
 
-    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertEq(steward.availableBudget(), availableBudget - debtDollarAmount);
 
     for (uint256 i = 0; i < usersWithBadDebt.length; i++) {
@@ -171,8 +171,8 @@ contract ClinicStewardV3Test is ClinicStewardV3BaseTest {
   }
 
   function test_reverts_batchRepayBadDebt_exceeded_pull_limit() public {
-    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalBadDebt) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
 
     uint256 newAvailableBudget = debtDollarAmount / 2;
 
@@ -219,8 +219,8 @@ contract ClinicStewardV3Test is ClinicStewardV3BaseTest {
     assertTrue(collectorBalanceBefore >= collectorBalanceAfter);
     assertTrue(collectorBalanceBefore - collectorBalanceAfter <= totalDebtToLiquidate);
 
-    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertEq(steward.availableBudget(), availableBudget - debtDollarAmount);
 
     assertTrue(collectorCollateralBalanceAfter >= collectorCollateralBalanceBefore);
@@ -261,8 +261,8 @@ contract ClinicStewardV3Test is ClinicStewardV3BaseTest {
     assertGe(collectorDebtUnderlyingBalanceAfter, collectorDebtUnderlyingBalanceBefore);
     assertLe(collectorBalanceBefore - collectorBalanceAfter, totalDebtToLiquidate + 1); // account for 1 wei rounding surplus
 
-    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * (totalDebtToLiquidate))
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * (totalDebtToLiquidate)) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
     assertApproxEqAbs(steward.availableBudget(), availableBudget - debtDollarAmount, 1);
 
     assertTrue(collectorCollateralBalanceAfter >= collectorCollateralBalanceBefore);
@@ -293,8 +293,8 @@ contract ClinicStewardV3Test is ClinicStewardV3BaseTest {
   }
 
   function test_reverts_batchLiquidate_exceeded_pull_limit() public {
-    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate)
-      / 10 ** IERC20Metadata(assetUnderlying).decimals();
+    uint256 debtDollarAmount = (AaveV3Avalanche.ORACLE.getAssetPrice(assetUnderlying) * totalDebtToLiquidate) / 10
+      ** IERC20Metadata(assetUnderlying).decimals();
 
     uint256 newAvailableBudget = debtDollarAmount / 2;
 

--- a/tests/risk/SvrOracleSteward.t.sol
+++ b/tests/risk/SvrOracleSteward.t.sol
@@ -9,7 +9,9 @@ import {AaveV3Ethereum, AaveV3EthereumAssets} from "aave-address-book/AaveV3Ethe
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {IAccessControl} from "openzeppelin-contracts/contracts/access/IAccessControl.sol";
 import {
-  Ownable, OwnableWithGuardian, IWithGuardian
+  Ownable,
+  OwnableWithGuardian,
+  IWithGuardian
 } from "solidity-utils/contracts/access-control/OwnableWithGuardian.sol";
 import {AggregatorInterface} from "aave-v3-origin/contracts/dependencies/chainlink/AggregatorInterface.sol";
 
@@ -154,8 +156,7 @@ contract SvrOracleStewardBaseTest is Test {
   function test_ifNoGuardian_activateSvrOracle_shouldRevert() external {
     SvrOracleSteward.AssetOracle[] memory configs = new ISvrOracleSteward.AssetOracle[](1);
     configs[0] = ISvrOracleSteward.AssetOracle({
-      asset: AaveV3EthereumAssets.cbBTC_UNDERLYING,
-      svrOracle: 0x77E55306eeDb1F94a4DcFbAa6628ef87586BC651
+      asset: AaveV3EthereumAssets.cbBTC_UNDERLYING, svrOracle: 0x77E55306eeDb1F94a4DcFbAa6628ef87586BC651
     });
     vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(this)));
     steward.enableSvrOracles(configs);


### PR DESCRIPTION
- Add LayerZero bridge steward, to send USDT from L2 collectors back to Mainnet collector
- Lint code with current forge version (required to pass CI checks). This is also included in #29; whichever PR gets merged first can be merged back into the second one.

See https://github.com/TokenLogic-com-au/aave-stewards/pull/9 for reference (internal discussion and review).